### PR TITLE
Add minimal schemads support for dsabstraction app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,10 @@ require (
 	github.com/grafana/grafana/apps/scope v0.0.0-20251007093103-792853df9134 // indirect
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20251007081214-26e147d01f0a // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
+	github.com/grafana/schemads v0.0.6 // indirect
+	github.com/huandu/go-clone v1.7.3 // indirect
+	github.com/huandu/go-sqlbuilder v1.39.1 // indirect
+	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/grafana/schemads v0.0.6 h1:Pz0fClDO0wfzb0THzgM8pyxVycbEa7b0ARS7YxfZ4RU=
+github.com/grafana/schemads v0.0.6/go.mod h1:4BnVcbwJT6xqyge9nB0GFbfzc6Aw3RzXD5TaZIOnPqY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
@@ -201,6 +203,15 @@ github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshf
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-assert v1.1.6 h1:oaAfYxq9KNDi9qswn/6aE0EydfxSa+tWZC1KabNitYs=
+github.com/huandu/go-assert v1.1.6/go.mod h1:JuIfbmYG9ykwvuxoJ3V8TB5QP+3+ajIA54Y44TmkMxs=
+github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
+github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
+github.com/huandu/go-sqlbuilder v1.39.1 h1:uUaj41yLNTQBe7ojNF6Im1RPbHCN4zCjMRySTEC2ooI=
+github.com/huandu/go-sqlbuilder v1.39.1/go.mod h1:zdONH67liL+/TvoUMwnZP/sUYGSSvHh9psLe/HpXn8E=
+github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
+github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jaegertracing/jaeger-idl v0.6.0 h1:LOVQfVby9ywdMPI9n3hMwKbyLVV3BL1XH2QqsP5KTMk=
@@ -320,6 +331,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=

--- a/pkg/promlib/flatten.go
+++ b/pkg/promlib/flatten.go
@@ -1,0 +1,106 @@
+package promlib
+
+import (
+	"sort"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// flattenTimeSeriesToTabular converts Prometheus multi-frame time series response
+// (one frame per label combination) into a single flat tabular frame with
+// timestamp, value, and label columns for dsabstraction compatibility.
+func flattenTimeSeriesToTabular(frames data.Frames) data.Frames {
+	if len(frames) == 0 {
+		return frames
+	}
+
+	type row struct {
+		t      time.Time
+		value  *float64
+		labels data.Labels
+	}
+
+	var rows []row
+	labelKeysSet := map[string]struct{}{}
+
+	for _, frame := range frames {
+		var timeField *data.Field
+		for _, f := range frame.Fields {
+			if f.Type() == data.FieldTypeTime || f.Type() == data.FieldTypeNullableTime {
+				timeField = f
+				break
+			}
+		}
+		if timeField == nil {
+			continue
+		}
+
+		for _, f := range frame.Fields {
+			if !f.Type().Numeric() {
+				continue
+			}
+			for k := range f.Labels {
+				if k != "__name__" {
+					labelKeysSet[k] = struct{}{}
+				}
+			}
+			for i := 0; i < f.Len(); i++ {
+				t := timeField.At(i).(time.Time)
+				v, err := f.FloatAt(i)
+				if err != nil {
+					continue
+				}
+				val := v
+				rows = append(rows, row{
+					t:      t,
+					value:  &val,
+					labels: f.Labels,
+				})
+			}
+		}
+	}
+
+	if len(rows) == 0 {
+		return frames
+	}
+
+	labelKeys := make([]string, 0, len(labelKeysSet))
+	for k := range labelKeysSet {
+		labelKeys = append(labelKeys, k)
+	}
+	sort.Strings(labelKeys)
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].t.Before(rows[j].t)
+	})
+
+	timestamps := make([]time.Time, len(rows))
+	values := make([]*float64, len(rows))
+	labelCols := make(map[string][]*string, len(labelKeys))
+	for _, k := range labelKeys {
+		labelCols[k] = make([]*string, len(rows))
+	}
+
+	for i, r := range rows {
+		timestamps[i] = r.t
+		values[i] = r.value
+		for _, k := range labelKeys {
+			if v, ok := r.labels[k]; ok {
+				labelCols[k][i] = &v
+			}
+		}
+	}
+
+	fields := make([]*data.Field, 0, 2+len(labelKeys))
+	fields = append(fields,
+		data.NewField("timestamp", nil, timestamps),
+		data.NewField("value", nil, values),
+	)
+	for _, k := range labelKeys {
+		fields = append(fields, data.NewField(k, nil, labelCols[k]))
+	}
+
+	out := data.NewFrame("", fields...)
+	return data.Frames{out}
+}

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -64,12 +64,16 @@ require (
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
+	github.com/grafana/schemads v0.0.6 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/huandu/go-clone v1.7.3 // indirect
+	github.com/huandu/go-sqlbuilder v1.39.1 // indirect
+	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jaegertracing/jaeger-idl v0.6.0 // indirect
 	github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 // indirect

--- a/pkg/promlib/go.sum
+++ b/pkg/promlib/go.sum
@@ -156,6 +156,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/grafana/schemads v0.0.6 h1:Pz0fClDO0wfzb0THzgM8pyxVycbEa7b0ARS7YxfZ4RU=
+github.com/grafana/schemads v0.0.6/go.mod h1:4BnVcbwJT6xqyge9nB0GFbfzc6Aw3RzXD5TaZIOnPqY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
@@ -168,6 +170,13 @@ github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshf
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
+github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
+github.com/huandu/go-sqlbuilder v1.39.1 h1:uUaj41yLNTQBe7ojNF6Im1RPbHCN4zCjMRySTEC2ooI=
+github.com/huandu/go-sqlbuilder v1.39.1/go.mod h1:zdONH67liL+/TvoUMwnZP/sUYGSSvHh9psLe/HpXn8E=
+github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
+github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jaegertracing/jaeger-idl v0.6.0 h1:LOVQfVby9ywdMPI9n3hMwKbyLVV3BL1XH2QqsP5KTMk=
@@ -274,6 +283,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -405,6 +415,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -103,7 +103,7 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	req = normalizeGrafanaSQLRequest(req)
+	req, schemadsRefIDs := normalizeGrafanaSQLRequest(req)
 
 	if len(req.Queries) == 0 {
 		err := fmt.Errorf("query contains no queries")
@@ -119,6 +119,16 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 	qd, err := i.queryData.Execute(ctx, req)
 	instrumentation.UpdateQueryDataMetrics(err, qd)
+
+	// Flatten schemads responses from multi-frame time series to single tabular frame.
+	if qd != nil && len(schemadsRefIDs) > 0 {
+		for refID, dr := range qd.Responses {
+			if _, ok := schemadsRefIDs[refID]; ok && dr.Error == nil {
+				dr.Frames = flattenTimeSeriesToTabular(dr.Frames)
+				qd.Responses[refID] = dr
+			}
+		}
+	}
 
 	return qd, err
 }

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -10,6 +10,7 @@ import (
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	schemas "github.com/grafana/schemads"
 
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/client"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/instrumentation"
@@ -23,8 +24,9 @@ type Service struct {
 }
 
 type instance struct {
-	queryData *querydata.QueryData
-	resource  *resource.Resource
+	queryData    *querydata.QueryData
+	resource     *resource.Resource
+	schemaDatasource *schemas.SchemaDatasource
 }
 
 type ExtendOptions func(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, log log.Logger) error
@@ -81,14 +83,28 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 			return nil, err
 		}
 
+		// Create schema provider for dsabstraction support
+		schemaProvider := resource.NewSchemaProvider(r)
+		schemaDs := schemas.NewSchemaDatasource(
+			schemaProvider, // SchemaHandler
+			schemaProvider, // TablesHandler
+			schemaProvider, // ColumnsHandler
+			nil,            // TableParameterValuesHandler
+			nil,            // ColumnValuesHandler
+			nil,            // fallback CallResourceHandler (handled below)
+		)
+
 		return instance{
-			queryData: qd,
-			resource:  r,
+			queryData:        qd,
+			resource:         r,
+			schemaDatasource: schemaDs,
 		}, nil
 	}
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	req = normalizeGrafanaSQLRequest(req)
+
 	if len(req.Queries) == 0 {
 		err := fmt.Errorf("query contains no queries")
 		instrumentation.UpdateQueryDataMetrics(err, nil)
@@ -111,6 +127,11 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return err
+	}
+
+	// Route schemads requests (abstractionSchema/*) through the SchemaDatasource handler.
+	if strings.HasPrefix(req.Path, schemas.BaseResourcePath) {
+		return i.schemaDatasource.CallResource(ctx, req, sender)
 	}
 
 	switch {

--- a/pkg/promlib/resource/schema.go
+++ b/pkg/promlib/resource/schema.go
@@ -1,0 +1,105 @@
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	schemas "github.com/grafana/schemads"
+)
+
+// SchemaProvider implements schemads SchemaHandler, TablesHandler, and ColumnsHandler
+// for the Prometheus datasource, providing schema metadata to the dsabstraction app.
+type SchemaProvider struct {
+	resource *Resource
+}
+
+func NewSchemaProvider(r *Resource) *SchemaProvider {
+	return &SchemaProvider{resource: r}
+}
+
+// metricsColumns is the fixed column schema for every Prometheus metric table.
+var metricsColumns = []schemas.Column{
+	{Name: "timestamp", Type: schemas.ColumnTypeDatetime},
+	{Name: "value", Type: schemas.ColumnTypeFloat64},
+}
+
+// Schema implements schemas.SchemaHandler.
+func (p *SchemaProvider) Schema(ctx context.Context, _ *schemas.SchemaRequest) (*schemas.SchemaResponse, error) {
+	tables, err := p.fetchMetricTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &schemas.SchemaResponse{
+		FullSchema: &schemas.Schema{
+			Tables: tables,
+		},
+	}, nil
+}
+
+// Tables implements schemas.TablesHandler.
+func (p *SchemaProvider) Tables(ctx context.Context, _ *schemas.TablesRequest) (*schemas.TablesResponse, error) {
+	names, err := p.fetchMetricNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &schemas.TablesResponse{Tables: names}, nil
+}
+
+// Columns implements schemas.ColumnsHandler.
+func (p *SchemaProvider) Columns(_ context.Context, req *schemas.ColumnsRequest) (*schemas.ColumnsResponse, error) {
+	columns := make(map[string][]schemas.Column, len(req.Tables))
+	for _, table := range req.Tables {
+		columns[table] = metricsColumns
+	}
+	return &schemas.ColumnsResponse{Columns: columns}, nil
+}
+
+// prometheusLabelsResponse is the JSON shape returned by /api/v1/label/__name__/values.
+type prometheusLabelsResponse struct {
+	Status string   `json:"status"`
+	Data   []string `json:"data"`
+}
+
+// fetchMetricNames calls the Prometheus /api/v1/label/__name__/values endpoint.
+func (p *SchemaProvider) fetchMetricNames(ctx context.Context) ([]string, error) {
+	path := "api/v1/label/__name__/values"
+	resp, err := p.resource.promClient.QueryResource(ctx, &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   path,
+		URL:    path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metric names: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result prometheusLabelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode metric names response: %w", err)
+	}
+
+	if result.Status != "success" {
+		return nil, fmt.Errorf("prometheus returned status %q for label values", result.Status)
+	}
+
+	return result.Data, nil
+}
+
+// fetchMetricTables returns schema Tables with the fixed columns for each metric.
+func (p *SchemaProvider) fetchMetricTables(ctx context.Context) ([]schemas.Table, error) {
+	names, err := p.fetchMetricNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tables := make([]schemas.Table, len(names))
+	for i, name := range names {
+		tables[i] = schemas.Table{
+			Name:    name,
+			Columns: metricsColumns,
+		}
+	}
+	return tables, nil
+}

--- a/pkg/promlib/resource/schema.go
+++ b/pkg/promlib/resource/schema.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"sort"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	schemas "github.com/grafana/schemads"
@@ -20,13 +22,16 @@ func NewSchemaProvider(r *Resource) *SchemaProvider {
 	return &SchemaProvider{resource: r}
 }
 
-// metricsColumns is the fixed column schema for every Prometheus metric table.
-var metricsColumns = []schemas.Column{
+// baseColumns are the fixed columns present in every Prometheus metric table.
+var baseColumns = []schemas.Column{
 	{Name: "timestamp", Type: schemas.ColumnTypeDatetime},
 	{Name: "value", Type: schemas.ColumnTypeFloat64},
 }
 
 // Schema implements schemas.SchemaHandler.
+// For fullSchema, tables are returned without label columns since that would
+// require a per-metric labels call for every metric. Use Columns() for
+// per-table label discovery.
 func (p *SchemaProvider) Schema(ctx context.Context, _ *schemas.SchemaRequest) (*schemas.SchemaResponse, error) {
 	tables, err := p.fetchMetricTables(ctx)
 	if err != nil {
@@ -49,15 +54,43 @@ func (p *SchemaProvider) Tables(ctx context.Context, _ *schemas.TablesRequest) (
 }
 
 // Columns implements schemas.ColumnsHandler.
-func (p *SchemaProvider) Columns(_ context.Context, req *schemas.ColumnsRequest) (*schemas.ColumnsResponse, error) {
+// For each requested table (metric), it fetches the label names from Prometheus
+// and returns timestamp + value + sorted label columns.
+func (p *SchemaProvider) Columns(ctx context.Context, req *schemas.ColumnsRequest) (*schemas.ColumnsResponse, error) {
 	columns := make(map[string][]schemas.Column, len(req.Tables))
-	for _, table := range req.Tables {
-		columns[table] = metricsColumns
+	for _, metric := range req.Tables {
+		labels, err := p.fetchLabelNames(ctx, metric)
+		if err != nil {
+			p.resource.log.Warn("failed to fetch labels for metric", "metric", metric, "error", err)
+			columns[metric] = baseColumns
+			continue
+		}
+		columns[metric] = buildMetricColumns(labels)
 	}
 	return &schemas.ColumnsResponse{Columns: columns}, nil
 }
 
-// prometheusLabelsResponse is the JSON shape returned by /api/v1/label/__name__/values.
+// buildMetricColumns returns timestamp + value + alphabetically sorted label columns.
+func buildMetricColumns(labels []string) []schemas.Column {
+	sort.Strings(labels)
+
+	cols := make([]schemas.Column, 0, len(baseColumns)+len(labels))
+	cols = append(cols, baseColumns...)
+	for _, label := range labels {
+		if label == "__name__" {
+			continue
+		}
+		cols = append(cols, schemas.Column{
+			Name:      label,
+			Type:      schemas.ColumnTypeString,
+			Operators: []schemas.Operator{schemas.OperatorEquals, schemas.OperatorIn},
+		})
+	}
+	return cols
+}
+
+// prometheusLabelsResponse is the JSON shape returned by /api/v1/labels and
+// /api/v1/label/__name__/values.
 type prometheusLabelsResponse struct {
 	Status string   `json:"status"`
 	Data   []string `json:"data"`
@@ -65,30 +98,47 @@ type prometheusLabelsResponse struct {
 
 // fetchMetricNames calls the Prometheus /api/v1/label/__name__/values endpoint.
 func (p *SchemaProvider) fetchMetricNames(ctx context.Context) ([]string, error) {
-	path := "api/v1/label/__name__/values"
+	return p.fetchPrometheusLabels(ctx, "api/v1/label/__name__/values", nil, "")
+}
+
+// fetchLabelNames calls /api/v1/labels?match[]=<metric> to get the label keys
+// for a specific metric.
+func (p *SchemaProvider) fetchLabelNames(ctx context.Context, metric string) ([]string, error) {
+	params := url.Values{}
+	params.Set("match[]", metric)
+	return p.fetchPrometheusLabels(ctx, "api/v1/labels", params, metric)
+}
+
+// fetchPrometheusLabels is the shared helper for fetching label data from Prometheus.
+func (p *SchemaProvider) fetchPrometheusLabels(ctx context.Context, path string, params url.Values, context string) ([]string, error) {
+	reqURL := path
+	if len(params) > 0 {
+		reqURL = path + "?" + params.Encode()
+	}
 	resp, err := p.resource.promClient.QueryResource(ctx, &backend.CallResourceRequest{
 		Method: http.MethodGet,
 		Path:   path,
-		URL:    path,
+		URL:    reqURL,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch metric names: %w", err)
+		return nil, fmt.Errorf("failed to fetch labels (context=%q): %w", context, err)
 	}
 	defer resp.Body.Close()
 
 	var result prometheusLabelsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode metric names response: %w", err)
+		return nil, fmt.Errorf("failed to decode labels response (context=%q): %w", context, err)
 	}
 
 	if result.Status != "success" {
-		return nil, fmt.Errorf("prometheus returned status %q for label values", result.Status)
+		return nil, fmt.Errorf("prometheus returned status %q (context=%q)", result.Status, context)
 	}
 
 	return result.Data, nil
 }
 
-// fetchMetricTables returns schema Tables with the fixed columns for each metric.
+// fetchMetricTables returns schema Tables with only the base columns.
+// Full per-metric label columns are discovered lazily via Columns().
 func (p *SchemaProvider) fetchMetricTables(ctx context.Context) ([]schemas.Table, error) {
 	names, err := p.fetchMetricNames(ctx)
 	if err != nil {
@@ -98,7 +148,7 @@ func (p *SchemaProvider) fetchMetricTables(ctx context.Context) ([]schemas.Table
 	for i, name := range names {
 		tables[i] = schemas.Table{
 			Name:    name,
-			Columns: metricsColumns,
+			Columns: baseColumns,
 		}
 	}
 	return tables, nil

--- a/pkg/promlib/sql.go
+++ b/pkg/promlib/sql.go
@@ -12,13 +12,16 @@ import (
 // normalizeGrafanaSQLRequest rewrites schemads tabular queries into native
 // Prometheus range queries. Queries without GrafanaSql=true are passed through
 // unchanged. The metric (table) name becomes the PromQL expression.
-func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) *backend.QueryDataRequest {
+// Returns the modified request and the set of refIDs that were schemads queries
+// (so their responses can be flattened).
+func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDataRequest, map[string]struct{}) {
 	if req == nil || len(req.Queries) == 0 {
-		return req
+		return req, nil
 	}
 
 	grafanaConfig := req.PluginContext.GrafanaConfig
 	queries := make([]backend.DataQuery, 0, len(req.Queries))
+	schemadsRefIDs := make(map[string]struct{})
 
 	for _, q := range req.Queries {
 		var query schemas.Query
@@ -62,8 +65,12 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) *backend.QueryDat
 
 		q.JSON = raw
 		queries = append(queries, q)
+		schemadsRefIDs[q.RefID] = struct{}{}
 	}
 
 	req.Queries = queries
-	return req
+	if len(schemadsRefIDs) == 0 {
+		return req, nil
+	}
+	return req, schemadsRefIDs
 }

--- a/pkg/promlib/sql.go
+++ b/pkg/promlib/sql.go
@@ -1,0 +1,69 @@
+package promlib
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	schemas "github.com/grafana/schemads"
+
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
+)
+
+// normalizeGrafanaSQLRequest rewrites schemads tabular queries into native
+// Prometheus range queries. Queries without GrafanaSql=true are passed through
+// unchanged. The metric (table) name becomes the PromQL expression.
+func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) *backend.QueryDataRequest {
+	if req == nil || len(req.Queries) == 0 {
+		return req
+	}
+
+	grafanaConfig := req.PluginContext.GrafanaConfig
+	queries := make([]backend.DataQuery, 0, len(req.Queries))
+
+	for _, q := range req.Queries {
+		var query schemas.Query
+		if err := json.Unmarshal(q.JSON, &query); err != nil {
+			queries = append(queries, q)
+			continue
+		}
+
+		if !query.GrafanaSql || query.Table == "" {
+			queries = append(queries, q)
+			continue
+		}
+
+		if grafanaConfig == nil {
+			backend.Logger.Warn("grafanaConfig is not set, skipping schemads query")
+			continue
+		}
+		if !grafanaConfig.FeatureToggles().IsEnabled("dsAbstractionApp") {
+			backend.Logger.Warn("dsAbstractionApp is not enabled, skipping schemads query")
+			continue
+		}
+
+		// The table name is the metric name — use it directly as the PromQL expression.
+		promQuery := models.QueryModel{
+			PrometheusQueryProperties: models.PrometheusQueryProperties{
+				Expr:   query.Table,
+				Range:  true,
+				Format: models.PromQueryFormatTimeSeries,
+			},
+		}
+		promQuery.RefID = query.RefID
+		promQuery.MaxDataPoints = q.MaxDataPoints
+		promQuery.IntervalMS = float64(q.Interval.Milliseconds())
+
+		raw, err := json.Marshal(promQuery)
+		if err != nil {
+			backend.Logger.Warn("failed to marshal prometheus query from schemads", "error", err)
+			queries = append(queries, q)
+			continue
+		}
+
+		q.JSON = raw
+		queries = append(queries, q)
+	}
+
+	req.Queries = queries
+	return req
+}


### PR DESCRIPTION
Implements schema discovery and query translation so the Prometheus datasource can be queried via the dsabstraction app's SQL interface.

- SchemaProvider exposes metric names as tables (via /api/v1/label/__name__/values) with fixed timestamp + value columns
- normalizeGrafanaSQLRequest translates schemads tabular queries into Prometheus range queries (metric name becomes PromQL expr)
- SchemaDatasource wired into CallResource for abstractionSchema/* paths
- Gated behind dsAbstractionApp feature toggle

(Done via claude)