### PR TITLE
Add prometheus_rate table function for dsabstraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,9 +146,11 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20210630183607-d20f26d13c79 // indirect
-	google.golang.org/grpc v1.79.1 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 )
 
 replace github.com/grafana/grafana-prometheus-datasource/pkg/promlib => ./pkg/promlib
+
+replace github.com/grafana/schemads => /home/kbrandt/go/src/github.com/grafana/schemads

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/schemads v0.0.6 h1:Pz0fClDO0wfzb0THzgM8pyxVycbEa7b0ARS7YxfZ4RU=
-github.com/grafana/schemads v0.0.6/go.mod h1:4BnVcbwJT6xqyge9nB0GFbfzc6Aw3RzXD5TaZIOnPqY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
@@ -502,8 +500,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.79.1 h1:zGhSi45ODB9/p3VAawt9a+O/MULLl9dpizzNNpq7flY=
-google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/promlib/flatten.go
+++ b/pkg/promlib/flatten.go
@@ -102,5 +102,17 @@ func flattenTimeSeriesToTabular(frames data.Frames) data.Frames {
 	}
 
 	out := data.NewFrame("", fields...)
+
+	// Preserve ExecutedQueryString from the source frames so the
+	// dsabstraction response includes the PromQL that was actually run.
+	for _, frame := range frames {
+		if frame.Meta != nil && frame.Meta.ExecutedQueryString != "" {
+			out.Meta = &data.FrameMeta{
+				ExecutedQueryString: frame.Meta.ExecutedQueryString,
+			}
+			break
+		}
+	}
+
 	return data.Frames{out}
 }

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/grafana/dskit v0.0.0-20260108123158-1a1acfb6ef2e
 	github.com/grafana/grafana-plugin-sdk-go v0.290.0
 	github.com/grafana/grafana/apps/scope v0.0.0-20251007093103-792853df9134
+	github.com/grafana/schemads v0.0.6
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
@@ -64,7 +65,6 @@ require (
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
-	github.com/grafana/schemads v0.0.6 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
@@ -128,7 +128,7 @@ require (
 	google.golang.org/api v0.256.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect
-	google.golang.org/grpc v1.79.1 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/client-go v0.35.1 // indirect
@@ -139,3 +139,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace github.com/grafana/schemads => /home/kbrandt/go/src/github.com/grafana/schemads

--- a/pkg/promlib/go.sum
+++ b/pkg/promlib/go.sum
@@ -156,8 +156,6 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/schemads v0.0.6 h1:Pz0fClDO0wfzb0THzgM8pyxVycbEa7b0ARS7YxfZ4RU=
-github.com/grafana/schemads v0.0.6/go.mod h1:4BnVcbwJT6xqyge9nB0GFbfzc6Aw3RzXD5TaZIOnPqY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
@@ -171,6 +169,8 @@ github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-assert v1.1.6 h1:oaAfYxq9KNDi9qswn/6aE0EydfxSa+tWZC1KabNitYs=
+github.com/huandu/go-assert v1.1.6/go.mod h1:JuIfbmYG9ykwvuxoJ3V8TB5QP+3+ajIA54Y44TmkMxs=
 github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
 github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-sqlbuilder v1.39.1 h1:uUaj41yLNTQBe7ojNF6Im1RPbHCN4zCjMRySTEC2ooI=
@@ -406,8 +406,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57/go.mod h1:kSJwQxqmFXeo79zOmbrALdflXQeAYcUbgS7PbpMknCY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 h1:mWPCjDEyshlQYzBpMNHaEof6UX1PmHcaUODUywQ0uac=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
-google.golang.org/grpc v1.79.1 h1:zGhSi45ODB9/p3VAawt9a+O/MULLl9dpizzNNpq7flY=
-google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -93,6 +93,7 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 			nil,            // ColumnValuesHandler
 			nil,            // fallback CallResourceHandler (handled below)
 		)
+		schemaDs.FunctionsHandler = schemaProvider
 
 		return instance{
 			queryData:        qd,

--- a/pkg/promlib/resource/schema.go
+++ b/pkg/promlib/resource/schema.go
@@ -70,6 +70,25 @@ func (p *SchemaProvider) Columns(ctx context.Context, req *schemas.ColumnsReques
 	return &schemas.ColumnsResponse{Columns: columns}, nil
 }
 
+// Functions implements schemas.FunctionsHandler.
+// Returns the table functions that the Prometheus datasource supports.
+func (p *SchemaProvider) Functions(_ context.Context, _ *schemas.FunctionsRequest) (*schemas.FunctionsResponse, error) {
+	return &schemas.FunctionsResponse{
+		Functions: []schemas.Function{
+			{
+				Name: "prometheus_rate",
+				Kind: schemas.FunctionKindTable,
+				Params: []schemas.FunctionParam{
+					{Name: "datasource", Type: schemas.ColumnTypeString, Required: true, Description: "Datasource reference (type::uid)"},
+					{Name: "metric", Type: schemas.ColumnTypeString, Required: true, Description: "Metric name"},
+					{Name: "duration", Type: schemas.ColumnTypeString, Required: true, Description: "Rate window (e.g. '5m')"},
+				},
+				Description: "Per-second rate of increase of a counter over the given duration window",
+			},
+		},
+	}, nil
+}
+
 // buildMetricColumns returns timestamp + value + alphabetically sorted label columns.
 func buildMetricColumns(labels []string) []schemas.Column {
 	sort.Strings(labels)

--- a/pkg/promlib/sql.go
+++ b/pkg/promlib/sql.go
@@ -49,8 +49,8 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 		}
 
 		// Build the PromQL expression using the Prometheus parser.
-		funcName, funcArgs := extractFunctionContext(q.JSON)
-		expr, err := buildPromQLExpr(query.Table, funcName, funcArgs, query.Filters)
+		funcName, funcArgs, agg := extractFunctionContext(q.JSON)
+		expr, err := buildPromQLExpr(query.Table, funcName, funcArgs, query.Filters, agg)
 		if err != nil {
 			backend.Logger.Warn("failed to build PromQL expression from schemads", "error", err)
 			queries = append(queries, q)
@@ -91,7 +91,7 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 // table function context, and schemads column filters. It uses the Prometheus
 // parser to build a proper AST rather than string concatenation, which makes
 // filter injection safe and composable.
-func buildPromQLExpr(metric, funcName string, funcArgs map[string]string, filters []schemas.ColumnFilter) (string, error) {
+func buildPromQLExpr(metric, funcName string, funcArgs map[string]string, filters []schemas.ColumnFilter, agg *aggregationContext) (string, error) {
 	// Build label matchers from schemads filters.
 	var matchers []*labels.Matcher
 	for _, f := range filters {
@@ -138,13 +138,61 @@ func buildPromQLExpr(metric, funcName string, funcArgs map[string]string, filter
 				},
 			},
 		}
-		return call.String(), nil
+		return wrapAggregation(call, agg), nil
 	case "":
 		// No function — plain metric query.
+		if agg != nil {
+			parsed, err := parser.ParseExpr(baseExpr)
+			if err != nil {
+				return baseExpr, nil
+			}
+			return wrapAggregation(parsed, agg), nil
+		}
 		return baseExpr, nil
 	default:
 		return "", fmt.Errorf("unsupported function %q", funcName)
 	}
+}
+
+// wrapAggregation wraps a PromQL expression with an aggregation operator
+// (e.g. sum by (method)(expr)) based on the pushdown context.
+func wrapAggregation(expr parser.Expr, agg *aggregationContext) string {
+	if agg == nil {
+		return expr.String()
+	}
+
+	// Map SQL aggregation function to PromQL aggregation type.
+	var aggType parser.ItemType
+	switch agg.Function {
+	case "SUM":
+		aggType = parser.SUM
+	case "AVG":
+		aggType = parser.AVG
+	case "COUNT":
+		aggType = parser.COUNT
+	case "MIN":
+		aggType = parser.MIN
+	case "MAX":
+		aggType = parser.MAX
+	default:
+		return expr.String()
+	}
+
+	// Filter out "timestamp" from GROUP BY — it's not a Prometheus label,
+	// it's the time axis. Also filter out the aggregated column itself.
+	var grouping []string
+	for _, g := range agg.GroupBy {
+		if g != "timestamp" && g != agg.Column {
+			grouping = append(grouping, g)
+		}
+	}
+
+	aggExpr := &parser.AggregateExpr{
+		Op:       aggType,
+		Expr:     expr,
+		Grouping: grouping,
+	}
+	return aggExpr.String()
 }
 
 // schemadsFilterToMatcher converts a schemads filter condition to a Prometheus
@@ -165,16 +213,23 @@ func schemadsFilterToMatcher(name string, cond schemas.FilterCondition) (*labels
 	return labels.NewMatcher(mt, name, value)
 }
 
-// extractFunctionContext extracts functionName and functionArgs from the raw
-// query JSON. These fields are set by the dsabstraction table function engine
-// when a query originates from a table function call.
-func extractFunctionContext(raw json.RawMessage) (string, map[string]string) {
+// aggregationContext describes an aggregation pushdown from the dsabstraction engine.
+type aggregationContext struct {
+	Function string   `json:"function"` // e.g. "SUM", "AVG"
+	Column   string   `json:"column"`   // e.g. "value"
+	GroupBy  []string `json:"groupBy"`  // e.g. ["timestamp", "method"]
+}
+
+// extractFunctionContext extracts functionName, functionArgs, and optional
+// aggregation context from the raw query JSON.
+func extractFunctionContext(raw json.RawMessage) (string, map[string]string, *aggregationContext) {
 	var payload struct {
-		FunctionName string            `json:"functionName"`
-		FunctionArgs map[string]string `json:"functionArgs"`
+		FunctionName string              `json:"functionName"`
+		FunctionArgs map[string]string   `json:"functionArgs"`
+		Aggregation  *aggregationContext `json:"aggregation"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", nil
+		return "", nil, nil
 	}
-	return payload.FunctionName, payload.FunctionArgs
+	return payload.FunctionName, payload.FunctionArgs, payload.Aggregation
 }

--- a/pkg/promlib/sql.go
+++ b/pkg/promlib/sql.go
@@ -44,10 +44,21 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 			continue
 		}
 
-		// The table name is the metric name — use it directly as the PromQL expression.
+		// Build the PromQL expression. If a table function is specified
+		// (e.g. prometheus_rate), wrap the metric accordingly.
+		expr := query.Table
+		funcName, funcArgs := extractFunctionContext(q.JSON)
+		if funcName == "prometheus_rate" {
+			duration := funcArgs["duration"]
+			if duration == "" {
+				duration = "5m"
+			}
+			expr = "rate(" + query.Table + "[" + duration + "])"
+		}
+
 		promQuery := models.QueryModel{
 			PrometheusQueryProperties: models.PrometheusQueryProperties{
-				Expr:   query.Table,
+				Expr:   expr,
 				Range:  true,
 				Format: models.PromQueryFormatTimeSeries,
 			},
@@ -73,4 +84,18 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 		return req, nil
 	}
 	return req, schemadsRefIDs
+}
+
+// extractFunctionContext extracts functionName and functionArgs from the raw
+// query JSON. These fields are set by the dsabstraction table function engine
+// when a query originates from a table function call.
+func extractFunctionContext(raw json.RawMessage) (string, map[string]string) {
+	var payload struct {
+		FunctionName string            `json:"functionName"`
+		FunctionArgs map[string]string `json:"functionArgs"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", nil
+	}
+	return payload.FunctionName, payload.FunctionArgs
 }

--- a/pkg/promlib/sql.go
+++ b/pkg/promlib/sql.go
@@ -2,8 +2,12 @@ package promlib
 
 import (
 	"encoding/json"
+	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	schemas "github.com/grafana/schemads"
 
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
@@ -44,16 +48,13 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 			continue
 		}
 
-		// Build the PromQL expression. If a table function is specified
-		// (e.g. prometheus_rate), wrap the metric accordingly.
-		expr := query.Table
+		// Build the PromQL expression using the Prometheus parser.
 		funcName, funcArgs := extractFunctionContext(q.JSON)
-		if funcName == "prometheus_rate" {
-			duration := funcArgs["duration"]
-			if duration == "" {
-				duration = "5m"
-			}
-			expr = "rate(" + query.Table + "[" + duration + "])"
+		expr, err := buildPromQLExpr(query.Table, funcName, funcArgs, query.Filters)
+		if err != nil {
+			backend.Logger.Warn("failed to build PromQL expression from schemads", "error", err)
+			queries = append(queries, q)
+			continue
 		}
 
 		promQuery := models.QueryModel{
@@ -84,6 +85,84 @@ func normalizeGrafanaSQLRequest(req *backend.QueryDataRequest) (*backend.QueryDa
 		return req, nil
 	}
 	return req, schemadsRefIDs
+}
+
+// buildPromQLExpr constructs a PromQL expression from a metric name, optional
+// table function context, and schemads column filters. It uses the Prometheus
+// parser to build a proper AST rather than string concatenation, which makes
+// filter injection safe and composable.
+func buildPromQLExpr(metric, funcName string, funcArgs map[string]string, filters []schemas.ColumnFilter) (string, error) {
+	// Build label matchers from schemads filters.
+	var matchers []*labels.Matcher
+	for _, f := range filters {
+		for _, cond := range f.Conditions {
+			m, err := schemadsFilterToMatcher(f.Name, cond)
+			if err != nil {
+				continue
+			}
+			matchers = append(matchers, m)
+		}
+	}
+
+	// Start with a plain metric selector.
+	baseExpr := metric
+	if len(matchers) > 0 {
+		// Build metric{label="value",...} via parser round-trip.
+		allMatchers := append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "__name__", metric)}, matchers...)
+		vs := &parser.VectorSelector{LabelMatchers: allMatchers}
+		baseExpr = vs.String()
+	}
+
+	// Wrap in function call if a table function is specified.
+	switch funcName {
+	case "prometheus_rate":
+		duration := funcArgs["duration"]
+		if duration == "" {
+			duration = "5m"
+		}
+		dur, err := time.ParseDuration(duration)
+		if err != nil {
+			return "", fmt.Errorf("invalid duration %q: %w", duration, err)
+		}
+		// Parse the base expression so we can wrap it in a Call AST node.
+		innerExpr, err := parser.ParseExpr(baseExpr)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse base expression %q: %w", baseExpr, err)
+		}
+		call := &parser.Call{
+			Func: parser.Functions["rate"],
+			Args: parser.Expressions{
+				&parser.MatrixSelector{
+					VectorSelector: innerExpr,
+					Range:          dur,
+				},
+			},
+		}
+		return call.String(), nil
+	case "":
+		// No function — plain metric query.
+		return baseExpr, nil
+	default:
+		return "", fmt.Errorf("unsupported function %q", funcName)
+	}
+}
+
+// schemadsFilterToMatcher converts a schemads filter condition to a Prometheus
+// label matcher.
+func schemadsFilterToMatcher(name string, cond schemas.FilterCondition) (*labels.Matcher, error) {
+	var mt labels.MatchType
+	switch cond.Operator {
+	case schemas.OperatorEquals:
+		mt = labels.MatchEqual
+	case schemas.OperatorNotEquals:
+		mt = labels.MatchNotEqual
+	case schemas.OperatorLike:
+		mt = labels.MatchRegexp
+	default:
+		return nil, fmt.Errorf("unsupported operator %q for Prometheus", cond.Operator)
+	}
+	value := fmt.Sprintf("%v", cond.Value)
+	return labels.NewMatcher(mt, name, value)
 }
 
 // extractFunctionContext extracts functionName and functionArgs from the raw


### PR DESCRIPTION
## Summary
- Register `prometheus_rate` as a schemads table function via `FunctionsHandler`
- When dsabstraction sends a query with `functionName: "prometheus_rate"`, the plugin wraps the metric as `rate(<metric>[<duration>])` in PromQL
- Enables: `SELECT * FROM prometheus_rate('prometheus::uid', 'up', '5m')`
- Enable filter and aggregation pushdown (can be controlled with query flags)

e.g.
```

   SQL: SELECT timestamp, job, SUM(value) as total FROM prometheus_rate('prometheus::uid', 'up', '5m') WHERE job 'prometheus' GROUP BY timestamp, job
   PromQL: sum by (job) (rate({__name__="up",job="prometheus"}[5m]))

'{"query": "SELECT timestamp, job, SUM(value) as total FROM prometheus_rate('\''prometheus::bfh6nkyxwj7cwf'\'', '\''up'\'', '\''5m'\'') WHERE job = '\''prometheus'\'' GROUP BY timestamp, job", "from": "now-5m", "to": "now"}'
```

Rate + Filter + Agg pushdown both OFF:
 ```
Body: {"filterPushdown": false, "aggPushdown": false}
   PromQL: rate(up[5m])
   Rows: 151 (GMS does both post-fetch)

     '{"query": "SELECT timestamp, job, SUM(value) as total FROM prometheus_rate('\''prometheus::bfh6nkyxwj7cwf'\'', '\''up'\'', '\''5m'\'') WHERE job = '\''prometheus'\'' GROUP BY timestamp, job", "from": "now-5m", "to": "now", "filterPushdown": false, "aggPushdown": false}'
```

Depends on grafana/schemads#21

## Test plan
- [x] `mage build:linux` passes
- [x] End-to-end tested: returns `rate(up[5m])` data with timestamp, value, and label columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)