### PR TITLE
Add npm publish workflow and development docs

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,94 @@
+name: Publish @grafana/prometheus to NPM
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (skip actual publish)'
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    name: Publish @grafana/prometheus
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Verify caller is a repo admin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${ACTOR}/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" ]]; then
+            echo "::error::Only repository admins can run this workflow. Your permission level: ${PERMISSION}"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check version is newer than npm
+        uses: EndBug/version-check@5102328418c0130d66ca712d755c303e93368ce2 # v2.1.7
+        id: version_check
+        with:
+          file-name: packages/grafana-prometheus/package.json
+          file-url: https://unpkg.com/@grafana/prometheus/package.json
+          static-checking: localIsNew
+
+      - name: Abort if version not newer
+        if: steps.version_check.outputs.changed != 'true'
+        run: |
+          echo "::error::Local version is not newer than npm. Bump the version in packages/grafana-prometheus/package.json first."
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      # npm trusted publishing (OIDC provenance) requires npm >= 11.5.1;
+      # GitHub Actions runners ship with an older version.
+      - name: Install npm >= 11.5.1
+        run: npm install -g npm@^11.5.1
+
+      - name: Install dependencies
+        run: cd packages/grafana-prometheus && npm ci
+
+      - name: Build library
+        run: cd packages/grafana-prometheus && npm run build
+
+      - name: Determine npm tag
+        id: npm_tag
+        env:
+          VERSION: ${{ steps.version_check.outputs.version }}
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to NPM
+        if: inputs.dry-run != true
+        working-directory: packages/grafana-prometheus
+        run: npm publish --access public --tag ${{ steps.npm_tag.outputs.tag }}
+
+      - name: Dry run summary
+        if: inputs.dry-run == true
+        env:
+          VERSION: ${{ steps.version_check.outputs.version }}
+          TAG: ${{ steps.npm_tag.outputs.tag }}
+        run: |
+          echo "## Dry run complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "Would publish @grafana/prometheus@${VERSION} with tag ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,92 @@
+# Development
+
+## Prerequisites
+
+- Node.js (see `.nvmrc` for version)
+- npm
+- Go (for backend builds)
+- Docker & Docker Compose (for e2e tests)
+
+## Getting started
+
+```bash
+npm install
+npm run build
+```
+
+## Project structure
+
+| Path | Description |
+|---|---|
+| `src/` | Plugin frontend source (webpack-built, bundled into the Grafana plugin zip) |
+| `packages/grafana-prometheus/` | `@grafana/prometheus` library (rollup-built, published to npm) |
+| `pkg/promlib/` | Go backend (`promlib`) |
+| `.config/` | Grafana plugin tooling config — **do not modify** |
+
+## Running locally
+
+Start Grafana with the plugin:
+
+```bash
+docker compose up -d
+```
+
+Grafana will be available at `http://localhost:3000`.
+
+## Testing
+
+```bash
+npm run test:ci          # unit tests
+npm run e2e              # playwright e2e tests (requires running Grafana)
+npm run lint             # eslint
+npm run typecheck        # typescript type checking
+```
+
+---
+
+## Publishing `@grafana/prometheus` to npm
+
+The `@grafana/prometheus` library is published from `packages/grafana-prometheus/` via a **manual** GitHub Actions workflow ([`release-npm.yml`](.github/workflows/release-npm.yml)). Publishing uses npm trusted publishing (OIDC) — no npm token secret is needed.
+
+### Dry run
+
+Validates the version check and build without publishing anything.
+
+1. Go to the repo on GitHub → **Actions** → **Publish @grafana/prometheus to NPM**.
+2. Click **Run workflow**.
+3. Select the branch (typically `main`).
+4. Check the **Dry run** checkbox.
+5. Click **Run workflow**.
+
+The workflow will build the library and print a summary of what *would* be published (version and npm dist-tag) without actually publishing.
+
+### Publishing a release
+
+1. **Bump the version** in `packages/grafana-prometheus/package.json` and merge to `main`.
+   The npm dist-tag is derived automatically from the version string:
+
+   | Version | npm tag |
+   |---|---|
+   | `1.2.0` | `latest` |
+   | `1.2.0-dev.1` | `dev` |
+   | `1.0.0-beta.3` | `beta` |
+
+2. Go to the repo on GitHub → **Actions** → **Publish @grafana/prometheus to NPM**.
+3. Click **Run workflow** → select `main` → leave **Dry run** unchecked → **Run workflow**.
+
+The workflow will fail with a clear error if the local version is not newer than what's already on npm.
+
+### Verifying a publish
+
+```bash
+npm view @grafana/prometheus versions --json
+npm view @grafana/prometheus dist-tags
+```
+
+### Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| "Local version is not newer than npm" | Bump the version in `packages/grafana-prometheus/package.json` first |
+| OIDC / provenance errors | Ensure the `npm-publish` GitHub environment exists and npm trusted publishing is configured for this repo |
+| Build fails | Run `cd packages/grafana-prometheus && npm ci && npm run build` locally to reproduce |

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -103,7 +103,7 @@
     "react-dom": "18.3.1",
     "react-select-event": "5.5.1",
     "rimraf": "6.0.1",
-    "rollup": "^4.22.4",
+    "rollup": "^4.60.1",
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-node-externals": "^8.0.0",
     "testing-library-selector": "0.3.1",


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-npm.yml` — a manual (`workflow_dispatch`) workflow for publishing `@grafana/prometheus` to npm using OIDC trusted publishing.
- Adds `DEVELOPMENT.md` with project structure, local development setup, and publishing instructions (dry-run and release).

### Workflow features

- **Manual trigger** with a dry-run option
- **Admin-only gate** — first step checks the caller has admin permission on the repo
- **Version safety** — compares local version against npm and fails if not newer
- **Prerelease tag derivation** — e.g. `1.0.0-dev.1` → npm tag `dev`, stable → `latest`
- **npm trusted publishing** (OIDC `id-token: write`, no `NPM_TOKEN` secret needed)
- **GitHub environment** — references `npm-publish` environment for deployment protection rules
- Actions pinned to commit hashes per security guidelines

### Prerequisites (before first publish)

1. Create `npm-publish` GitHub environment on this repo (Settings → Environments)
2. Configure npm trusted publishing for `@grafana/prometheus` on npmjs.com
3. Coordinate ownership transfer from grafana/grafana pipeline

## Test plan

- [ ] Verify YAML is valid and workflow appears in Actions tab after merge
- [ ] Trigger a dry-run on `main` — confirm version check and build succeed
- [ ] Trigger an actual publish after bumping the version — confirm package appears on npm

Made with [Cursor](https://cursor.com)