### PR TITLE
Fix: remove @grafana-app/source export condition that breaks consumers

### DIFF
--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/prometheus",
-  "version": "13.1.1,
+  "version": "13.1.1",
   "description": "Grafana Prometheus Library",
   "keywords": [
     "typescript",

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -21,7 +21,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "@grafana-app/source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/prometheus",
-  "version": "13.1.0",
+  "version": "13.1.1,
   "description": "Grafana Prometheus Library",
   "keywords": [
     "typescript",


### PR DESCRIPTION
## Summary

- Removes the `@grafana-app/source` export condition from `packages/grafana-prometheus/package.json`

## Problem

After publishing `@grafana/prometheus` 13.1.0 as a standalone npm package and consuming it in `grafana/grafana`, running `yarn start` fails with 10 webpack errors:

```
Module not found: Error: Can't resolve '@grafana/prometheus'
```

### Root cause

The `exports` field in `package.json` contains:

```json
"exports": {
  ".": {
    "@grafana-app/source": "./src/index.ts",  // <-- problem
    "types": "./dist/types/index.d.ts",
    "import": "./dist/esm/index.mjs",
    "require": "./dist/cjs/index.cjs"
  }
}
```

Grafana's webpack config (`scripts/webpack/webpack.common.js`) uses:

```js
conditionNames: ['@grafana-app/source', '...'],
```

This tells webpack to resolve the `@grafana-app/source` condition **first**. It points to `./src/index.ts`, but the `src/` directory is **not included in the published npm package** — only `dist/` is shipped (via the `files` field). So webpack resolves the condition, tries to load `./src/index.ts`, and fails because the file doesn't exist.

### Why this condition existed

`@grafana-app/source` was a monorepo convenience. When `@grafana/prometheus` lived inside `grafana/grafana` as a workspace package, this condition let webpack compile it directly from TypeScript source for faster dev builds. Now that it's an external npm package with pre-built dist files, this condition is no longer appropriate.

### Fix

Remove the `@grafana-app/source` condition so webpack falls through to `"import": "./dist/esm/index.mjs"`, which exists in the published package and works correctly.

## Test plan

- [ ] Publish a new version with this fix
- [ ] Update `grafana/grafana` to use the new version
- [ ] Verify `yarn start` in `grafana/grafana` compiles without `Can't resolve '@grafana/prometheus'` errors

Made with [Cursor](https://cursor.com)