### PR TITLE
Chore: fix typecheck by resolving @grafana/prometheus path alias

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,32 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+artifacts/
+work/
+ci/
+
+# Test outputs
+playwright-report/
+blob-report/
+test-results/
+coverage/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Yarn
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.pnp.*
+
+# Cache
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4 && yarn workspace @grafana/prometheus test:ci",
-    "typecheck": "tsc --noEmit && yarn workspace @grafana/prometheus typecheck",
+    "typecheck": "tsc -p ./packages/grafana-prometheus/tsconfig.build.json && tsc --noEmit && yarn workspace @grafana/prometheus typecheck",
     "lint": "eslint --cache . && yarn workspace @grafana/prometheus lint",
     "lint:fix": "eslint --cache --fix . && prettier --write --list-different . && yarn workspace @grafana/prometheus lint:fix",
     "e2e": "playwright test",

--- a/packages/grafana-prometheus/src/components/PromQueryField.test.tsx
+++ b/packages/grafana-prometheus/src/components/PromQueryField.test.tsx
@@ -1,6 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
 import { getByTestId, render, screen } from '@testing-library/react';
-// @ts-ignore
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, type DataFrame, dateTime, LoadingState, type PanelData } from '@grafana/data';

--- a/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
+++ b/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
@@ -11,10 +11,8 @@ import { InlineField, Switch, useTheme2 } from '@grafana/ui';
 
 import { docsTip, overhaulStyles } from './shared/utils';
 
-interface Props<T extends DataSourceJsonData> extends Pick<
-  DataSourcePluginOptionsEditorProps<T>,
-  'options' | 'onOptionsChange'
-> {}
+interface Props<T extends DataSourceJsonData>
+  extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {}
 
 interface AlertingConfig extends DataSourceJsonData {
   manageAlerts?: boolean;

--- a/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
+++ b/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
@@ -11,8 +11,10 @@ import { InlineField, Switch, useTheme2 } from '@grafana/ui';
 
 import { docsTip, overhaulStyles } from './shared/utils';
 
-interface Props<T extends DataSourceJsonData>
-  extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {}
+interface Props<T extends DataSourceJsonData> extends Pick<
+  DataSourcePluginOptionsEditorProps<T>,
+  'options' | 'onOptionsChange'
+> {}
 
 interface AlertingConfig extends DataSourceJsonData {
   manageAlerts?: boolean;
@@ -24,8 +26,6 @@ export function AlertingSettingsOverhaul<T extends AlertingConfig>({
   onOptionsChange,
 }: Props<T>): JSX.Element {
   const theme = useTheme2();
-  // imported GrafanaTheme2 from @grafana/data does not match type of same from @grafana/ui
-  // @ts-ignore
   const styles = overhaulStyles(theme);
 
   return (

--- a/src/configuration/AzureCredentialsConfig.ts
+++ b/src/configuration/AzureCredentialsConfig.ts
@@ -9,7 +9,6 @@ import {
   updateDatasourceCredentials,
 } from '@grafana/azure-sdk';
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
-// @ts-ignore - @grafana/prometheus not yet available; remove once resolved
 import { PromOptions } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
 

--- a/src/configuration/ConfigEditorPackage.tsx
+++ b/src/configuration/ConfigEditorPackage.tsx
@@ -5,7 +5,6 @@ import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { hasCredentials } from '@grafana/azure-sdk';
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
 import { AdvancedHttpSettings, ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
-// @ts-ignore - @grafana/prometheus not yet available; remove once resolved
 import { AlertingSettingsOverhaul, PromOptions, PromSettings } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
 import { Alert, FieldValidationMessage, TextLink, useTheme2 } from '@grafana/ui';

--- a/src/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/src/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -2,7 +2,6 @@ import { ReactElement, useState } from 'react';
 import * as React from 'react';
 
 import { Auth, ConnectionSettings, convertLegacyAuthProps, AuthMethod } from '@grafana/plugin-ui';
-// @ts-ignore - @grafana/prometheus not yet available; remove once resolved
 import { docsTip, overhaulStyles } from '@grafana/prometheus';
 import { Alert, SecureSocksProxySettings, useTheme2 } from '@grafana/ui';
 // @ts-ignore - @grafana/ui/internal not yet exported; remove once available
@@ -50,7 +49,6 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
   // for custom auth methods sigV4 and azure auth
   let customMethods: CustomMethod[] = [];
 
-  // @ts-ignore - sigV4Auth not on AzurePromDataSourceOptions; remove once resolved
   const [sigV4Selected, setSigV4Selected] = useState<boolean>(options.jsonData.sigV4Auth || false);
 
   const sigV4Id = 'custom-sigV4Id';
@@ -171,7 +169,6 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
             jsonData: {
               ...options.jsonData,
               azureCredentials: method === azureAuthId ? options.jsonData.azureCredentials : undefined,
-              // @ts-ignore - sigV4Auth not on AzurePromDataSourceOptions; remove once resolved
               sigV4Auth: method === sigV4Id,
               oauthPassThru: method === AuthMethod.OAuthForward,
             },

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,4 @@
 // global is used in packages/grafana-prometheus/src for dispatching events outside Monaco.
 // It is identical to globalThis in both Node.js and modern browsers.
+// eslint-disable-next-line no-var
 declare var global: typeof globalThis;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+// global is used in packages/grafana-prometheus/src for dispatching events outside Monaco.
+// It is identical to globalThis in both Node.js and modern browsers.
+declare var global: typeof globalThis;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,9 @@
 import { DataSourcePlugin } from '@grafana/data';
-// @ts-ignore - @grafana/prometheus not yet available; remove once resolved
 import { PrometheusDatasource, PromQueryEditorByApp, PromCheatSheet } from '@grafana/prometheus';
 
 import { ConfigEditor } from './configuration/ConfigEditorPackage';
 
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)
-  // @ts-ignore - ConfigEditor type mismatch until @grafana/prometheus is resolved
   .setConfigEditor(ConfigEditor)
   .setQueryEditorHelp(PromCheatSheet);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "./.config/tsconfig.json",
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "rootDir": ".",
+    "paths": {
+      "@grafana/prometheus": ["packages/grafana-prometheus/src/index"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

TypeScript could not resolve `@grafana/prometheus` imports from the plugin root because it was treated as an external package rather than the local workspace package. This caused widespread `@ts-ignore` suppressions that hid real type errors and made the `typecheck` script unreliable.

- Adds a `paths` alias in `tsconfig.json` pointing `@grafana/prometheus` at `packages/grafana-prometheus/src/index`, so TypeScript resolves types from source.
- Extends the `typecheck` script to also compile the inner package (`packages/grafana-prometheus/tsconfig.build.json`), catching errors in both workspaces in a single run.
- Adds `src/global.d.ts` to declare the `global` variable referenced inside the grafana-prometheus package.
- Removes all `@ts-ignore` comments that were suppressing the import resolution failures across `src/module.ts`, `src/configuration/`, and `packages/grafana-prometheus/src/`.

## Test plan

- [x] Run `yarn typecheck` — should pass with no errors and no suppressions
- [x] Run `yarn test:ci` — no regressions
- [x] Confirm no `@ts-ignore` comments remain for `@grafana/prometheus` import resolution