### PR TITLE
Chore: Update readme and plugin-id in various places

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -25,7 +25,7 @@ services:
 
     environment:
       NODE_ENV: development
-      GF_LOG_FILTERS: plugin.grafana-prometheus-datasource:debug
+      GF_LOG_FILTERS: plugin.prometheus:debug
       GF_LOG_LEVEL: debug
       GF_DATAPROXY_LOGGING: 1
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-prometheus-datasource
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: prometheus

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 [Prometheus](https://prometheus.io/) is an open-source time series database and
 alerting system. The Prometheus data source plugin lets Grafana query, visualize,
 and alert on metrics stored in Prometheus or any Prometheus-compatible backend
-(for example [Grafana Mimir](https://grafana.com/oss/mimir/), [Cortex](https://cortexmetrics.io/), [Thanos](https://thanos.io/) or [Amazon Managed
-Service for Prometheus](https://docs.aws.amazon.com/prometheus/)).
+(for example [Grafana Mimir](https://grafana.com/oss/mimir/), [Cortex](https://cortexmetrics.io/), [Thanos](https://thanos.io/)).
 
 This repository hosts:
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [Prometheus](https://prometheus.io/) is an open-source time series database and
 alerting system. The Prometheus data source plugin lets Grafana query, visualize,
 and alert on metrics stored in Prometheus or any Prometheus-compatible backend
-(for example Grafana Mimir, Cortex, Thanos, VictoriaMetrics, or Amazon Managed
-Service for Prometheus).
+(for example [Grafana Mimir](https://grafana.com/oss/mimir/), [Cortex](https://cortexmetrics.io/), [Thanos](https://thanos.io/) or [Amazon Managed
+Service for Prometheus](https://docs.aws.amazon.com/prometheus/)).
 
 This repository hosts:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,53 @@
-# Prometheus datasource plugin
+# Prometheus data source for Grafana
 
-[`promlib`](https://github.com/grafana/grafana-prometheus-datasource/tree/main/pkg/promlib) has been migrated out of `grafana/grafana` and is now hosted in this package. It is production-ready and actively used.
+> **Note**: This core plugin was extracted from the
+> [grafana/grafana](https://github.com/grafana/grafana) repository and is now
+> developed and released from this repository.
 
-The datasource, however, is WIP: under heavy development, will eat your lunch and your chickens. DO NOT USE.
+## Overview
+
+[Prometheus](https://prometheus.io/) is an open-source time series database and
+alerting system. The Prometheus data source plugin lets Grafana query, visualize,
+and alert on metrics stored in Prometheus or any Prometheus-compatible backend
+(for example Grafana Mimir, Cortex, Thanos, VictoriaMetrics, or Amazon Managed
+Service for Prometheus).
+
+This repository hosts:
+
+- The plugin frontend — published to npm as
+  [`@grafana/prometheus`](https://www.npmjs.com/package/@grafana/prometheus) and
+  consumed by Grafana core until the plugin is removed from the monorepo.
+- The plugin backend — the `promlib` Go library under
+  [`pkg/promlib`](./pkg/promlib), consumed by Grafana core via a
+  `go.mod` replace until the plugin is removed from the monorepo.
+- The standalone plugin binary built from `pkg/main.go` and
+  `pkg/datasource.go`, distributed through the Grafana plugin catalog.
+
+## Requirements
+
+- Grafana 12.3.0 or later (see `dependencies.grafanaDependency` in
+  [`src/plugin.json`](./src/plugin.json)).
+
+## Getting started
+
+For Grafana versions where Prometheus is still bundled as a core data source,
+no installation is required.
+
+For detailed setup instructions, see the
+[Prometheus data source documentation](https://grafana.com/docs/grafana/latest/datasources/prometheus/).
+
+## Issues
+
+Please report bugs and feature requests at
+[grafana/grafana-prometheus-datasource/issues](https://github.com/grafana/grafana-prometheus-datasource/issues/new).
+
+## Contributing
+
+Follow the
+[Grafana plugin development guide](https://grafana.com/developers/plugin-tools/)
+for local development. Run `mage -v` to build the backend and
+`yarn dev` (or `yarn build`) for the frontend.
+
+## License
+
+This plugin is licensed under the [AGPL-3.0](LICENSE).

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -49,6 +49,21 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 	return d.Service.CheckHealth(ctx, req)
 }
 
+func (d *Datasource) ValidateAdmission(ctx context.Context, req *backend.AdmissionRequest) (*backend.ValidationResponse, error) {
+	ctx = d.contextualMiddlewares(ctx)
+	return d.Service.ValidateAdmission(ctx, req)
+}
+
+func (d *Datasource) MutateAdmission(ctx context.Context, req *backend.AdmissionRequest) (*backend.MutationResponse, error) {
+	ctx = d.contextualMiddlewares(ctx)
+	return d.Service.MutateAdmission(ctx, req)
+}
+
+func (d *Datasource) ConvertObjects(ctx context.Context, req *backend.ConversionRequest) (*backend.ConversionResponse, error) {
+	ctx = d.contextualMiddlewares(ctx)
+	return d.Service.ConvertObjects(ctx, req)
+}
+
 func (d *Datasource) contextualMiddlewares(ctx context.Context) context.Context {
 	cfg := config.GrafanaConfigFromContext(ctx)
 

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if err := datasource.Manage("grafana-prometheus-datasource", NewDatasource, datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("prometheus", NewDatasource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

Gate 0 readiness fixes for the externalized Prometheus plugin before publishing to the dev plugin catalog.

- **Admission/conversion handlers** (`pkg/datasource.go`): expose `ValidateAdmission`, `MutateAdmission`, and `ConvertObjects` as passthroughs to `promlib.Service` (with `contextualMiddlewares` applied) so the K8s-backed datasource API path in `grafana/grafana` works against the external binary.
- **Plugin id → `prometheus`** (`pkg/main.go`, `.config/docker-compose-base.yaml`): match the core plugin id so core-as-external resolves correctly.
- **README rewrite**: remove the "WIP / DO NOT USE" warning, describe the npm package, `pkg/promlib`, and the standalone binary, state the Grafana version requirement, and link the issue tracker and docs.

Tracker: `plan-prometheus-externalization.md` — Gate 0 (G0.3 + G0.4).

## Test plan

- [x] `go build ./pkg/...` and `go test ./pkg/...`
- [x] `cd pkg/promlib && go build ./...`
- [x] `mage` builds all 8 platform binaries; `admission` symbols present
- [x] No `do not use` left in `README.md`
- [ ] Reviewer to confirm no regression on the standard query / call-resource paths

Made with [Cursor](https://cursor.com)