### PR TITLE
Prometheus: Fix Builder support for dotted metric and label names

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
@@ -126,6 +126,55 @@ describe('buildVisualQueryFromString', () => {
         errors: [],
       });
     });
+
+    it('reconstructs raw dotted metric names', () => {
+      expect(buildVisualQueryFromString('http.server.request.duration')).toEqual(
+        noErrors({
+          labels: [],
+          metric: 'http.server.request.duration',
+          operations: [],
+        })
+      );
+    });
+
+    it('reconstructs raw dotted metric names with labels', () => {
+      expect(buildVisualQueryFromString('http.server.request.duration{job="api-server"}')).toEqual(
+        noErrors({
+          labels: [
+            {
+              label: 'job',
+              op: '=',
+              value: 'api-server',
+            },
+          ],
+          metric: 'http.server.request.duration',
+          operations: [],
+        })
+      );
+    });
+
+    it('reconstructs raw dotted metric names in range functions', () => {
+      expect(
+        buildVisualQueryFromString('rate(http.server.request.duration{job="api-server"}[$__rate_interval])')
+      ).toEqual(
+        noErrors({
+          labels: [
+            {
+              label: 'job',
+              op: '=',
+              value: 'api-server',
+            },
+          ],
+          metric: 'http.server.request.duration',
+          operations: [
+            {
+              id: 'rate',
+              params: ['$__rate_interval'],
+            },
+          ],
+        })
+      );
+    });
   });
 
   it('creates no errors for empty query', () => {

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -44,6 +44,26 @@ import {
 import { type QueryBuilderLabelFilter, type QueryBuilderOperation } from './shared/types';
 import { type PromVisualQuery, type PromVisualQueryBinary } from './types';
 
+const DOTTED_METRIC_PATTERN = /^([a-zA-Z_:][a-zA-Z0-9_:]*(?:\.[a-zA-Z_:][a-zA-Z0-9_:]*)+)/;
+
+function tryReconstructDottedMetric(expr: string, node: SyntaxNode): { name: string; from: number; to: number } | null {
+  if (node.type.id !== VectorSelector) {
+    return null;
+  }
+
+  const nodeText = expr.slice(node.from, node.to);
+  const match = nodeText.match(DOTTED_METRIC_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    name: match[1],
+    from: node.from,
+    to: node.from + match[1].length,
+  };
+}
+
 /**
  * Parses a PromQL query into a visual query model.
  *
@@ -87,6 +107,7 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
 
   // No need to return replaced variables
   delete context.replacements;
+  delete context.reconstructedMetricRange;
 
   return context;
 }
@@ -102,6 +123,7 @@ interface Context {
   query: PromVisualQuery;
   errors: ParsingError[];
   replacements?: Record<string, string>;
+  reconstructedMetricRange?: { from: number; to: number };
 }
 
 /**
@@ -146,6 +168,17 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
     }
 
     case UnquotedLabelMatcher: {
+      const matchOp = node.getChild(MatchOp);
+      if (!matchOp && visQuery.metric === '') {
+        const matcherText = expr.slice(node.from, node.to).trim();
+        const dottedMatch = matcherText.match(DOTTED_METRIC_PATTERN);
+        if (dottedMatch && dottedMatch[1] === matcherText) {
+          visQuery.metric = dottedMatch[1];
+          context.reconstructedMetricRange = { from: node.from, to: node.to };
+          break;
+        }
+      }
+
       // Same as MetricIdentifier should be just one per query.
       visQuery.labels.push(getLabel(expr, node, LabelName));
       const err = node.getChild(ErrorId);
@@ -174,6 +207,13 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
       if (isIntervalVariableError(node)) {
         break;
       }
+      if (
+        context.reconstructedMetricRange &&
+        node.from >= context.reconstructedMetricRange.from &&
+        node.to <= context.reconstructedMetricRange.to
+      ) {
+        break;
+      }
       context.errors.push(makeError(expr, node));
       break;
     }
@@ -183,6 +223,22 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
         // We don't support parenthesis in the query to group expressions.
         // We just report error but go on with the parsing.
         context.errors.push(makeError(expr, node));
+      }
+      if (node.type.id === VectorSelector && visQuery.metric === '') {
+        const dotted = tryReconstructDottedMetric(expr, node);
+        if (dotted) {
+          visQuery.metric = dotted.name;
+          context.reconstructedMetricRange = { from: dotted.from, to: dotted.to };
+
+          let child = node.firstChild;
+          while (child) {
+            if (child.from >= dotted.to) {
+              handleExpression(expr, child, context);
+            }
+            child = child.nextSibling;
+          }
+          break;
+        }
       }
       // Any other nodes we just ignore and go to its children. This should be fine as there are lots of wrapper
       // nodes that can be skipped.

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
@@ -5,6 +5,7 @@ import {
   getLeftMostChild,
   getString,
   isFunctionOrAggregation,
+  regexifyLabelValuesQueryString,
   replaceBuiltInVariable,
   replaceVariables,
   returnBuiltInVariable,
@@ -57,6 +58,14 @@ describe('getString', () => {
       __V_2__app__V__: '${app}',
       __V_0____interval__V__: '$__interval',
     });
+  });
+});
+
+describe('regexifyLabelValuesQueryString', () => {
+  it('escapes regex special characters in metric search text', () => {
+    expect(regexifyLabelValuesQueryString('http.server request[duration]')).toBe(
+      'http\\\\.server.*request\\\\[duration\\\\].*'
+    );
   });
 });
 

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
@@ -2,6 +2,8 @@
 import { type SyntaxNode, type TreeCursor } from '@lezer/common';
 import { AggregateExpr, FunctionCallBody } from '@prometheus-io/lezer-promql';
 
+import { escapeLabelValueInRegexSelector } from '../escaping';
+
 import { type QueryBuilderOperation, type QueryBuilderOperationParamValue } from './shared/types';
 
 // Although 0 isn't explicitly provided in the lezer-promql library as the error node ID, it does appear to be the ID of error nodes within lezer.
@@ -141,7 +143,7 @@ export function getAllByType(expr: string, cur: SyntaxNode, type: number): strin
  */
 export const regexifyLabelValuesQueryString = (query: string) => {
   const queryArray = query.split(' ');
-  return queryArray.map((query) => `${query}.*`).join('');
+  return queryArray.map((query) => `${escapeLabelValueInRegexSelector(query)}.*`).join('');
 };
 
 /**

--- a/packages/grafana-prometheus/src/resource_clients.test.ts
+++ b/packages/grafana-prometheus/src/resource_clients.test.ts
@@ -117,14 +117,31 @@ describe('LabelsApiClient', () => {
       );
     });
 
-    it('should handle UTF-8 label names', async () => {
+    it('should use raw dotted label names in the label values URL path', async () => {
       mockRequest.mockResolvedValueOnce(['value1', 'value2']);
       mockInterpolateString.mockImplementationOnce((str) => 'http.status:sum');
 
       await client.queryLabelValues(mockTimeRange, '"http.status:sum"');
 
       expect(mockRequest).toHaveBeenCalledWith(
-        '/api/v1/label/U__http_2e_status:sum/values',
+        '/api/v1/label/http.status:sum/values',
+        {
+          start: expect.any(String),
+          end: expect.any(String),
+          limit: 40000,
+        },
+        defaultCacheHeaders
+      );
+    });
+
+    it('should interpolate dotted label names before building the label values URL path', async () => {
+      mockRequest.mockResolvedValueOnce(['app', 'sidecar']);
+      mockInterpolateString.mockImplementationOnce(() => 'k8s.container.name');
+
+      await client.queryLabelValues(mockTimeRange, '$label');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/api/v1/label/k8s.container.name/values',
         {
           start: expect.any(String),
           end: expect.any(String),
@@ -490,6 +507,42 @@ describe('SeriesApiClient', () => {
         '/api/v1/series',
         expect.objectContaining({
           'match[]': '{__name__="metric.name",instance="test",job!=""}',
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should create a proper matcher when the given match is a raw dotted metric name only', async () => {
+      mockRequest.mockResolvedValue([
+        { __name__: 'metric.one', job: 'grafana' },
+        { __name__: 'metric.one', job: 'prometheus' },
+      ]);
+
+      await client.queryLabelValues(mockTimeRange, 'job', 'metric.one');
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/api/v1/series',
+        expect.objectContaining({
+          'match[]': '{__name__="metric.one",job!=""}',
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should create a proper matcher when the given match is a raw dotted metric query', async () => {
+      mockRequest.mockResolvedValue([
+        { __name__: 'metric.one', job: 'grafana' },
+        { __name__: 'metric.one', job: 'prometheus' },
+      ]);
+
+      await client.queryLabelValues(mockTimeRange, 'job', 'metric.one{instance="test"}');
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/api/v1/series',
+        expect.objectContaining({
+          'match[]': '{__name__="metric.one",instance="test",job!=""}',
         }),
         expect.any(Object)
       );

--- a/packages/grafana-prometheus/src/resource_clients.ts
+++ b/packages/grafana-prometheus/src/resource_clients.ts
@@ -7,7 +7,7 @@ import { type PrometheusDatasource } from './datasource';
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { PrometheusCacheLevel } from './types';
-import { escapeForUtf8Support, utf8Support } from './utf8_support';
+import { utf8Support } from './utf8_support';
 
 type PrometheusSeriesResponse = Array<{ [key: string]: string }>;
 type PrometheusLabelsResponse = string[];
@@ -170,14 +170,14 @@ export class LabelsApiClient extends BaseResourceClient implements ResourceApiCl
     const effectiveLimit = this.getEffectiveLimit(limit);
     const searchParams = { limit: effectiveLimit, ...timeParams, ...(match ? { 'match[]': match } : {}) };
     const interpolatedName = this.datasource.interpolateString(labelKey);
-    const interpolatedAndEscapedName = escapeForUtf8Support(removeQuotesIfExist(interpolatedName));
-    const effectiveMatch = `${match ?? ''}-${interpolatedAndEscapedName}`;
+    const cleanName = removeQuotesIfExist(interpolatedName);
+    const effectiveMatch = `${match ?? ''}-${cleanName}`;
     const maybeCachedValues = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
     if (maybeCachedValues) {
       return maybeCachedValues;
     }
 
-    const url = `/api/v1/label/${interpolatedAndEscapedName}/values`;
+    const url = `/api/v1/label/${cleanName}/values`;
     const value = await this.requestLabels(url, searchParams, getDefaultCacheHeaders(this.datasource.cacheLevel));
     this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, value ?? []);
     return value ?? [];


### PR DESCRIPTION
## What is this fix?

Fixes `@grafana/prometheus` Builder handling for raw dotted OTel-style metric and label names such as `http.server.request.duration` and `k8s.container.name`.

The Prometheus query/code path can already work with Prometheus 3 UTF-8 syntax once the query is represented as quoted PromQL. Builder has additional client-side parsing and label-value lookup steps before that point, and those steps currently break when backends expose raw dotted names through metadata/autocomplete APIs.

This PR:

- Stops applying Prometheus `U__...` escaping to label names in the `/api/v1/label/{name}/values` URL path.
- Reconstructs raw dotted metric names when the lezer PromQL parser splits them into partial identifiers/error nodes.
- Escapes regex metacharacters in Builder metric search text so dots are matched literally.
- Adds coverage for dotted label value lookups, raw dotted metric parsing, range functions, and Builder metric search filtering.

## Why

OpenTelemetry semantic conventions commonly use dot notation for metric and attribute names. Backends can expose those names natively, and Builder needs to turn them into the existing visual model before rendering valid PromQL.

Related to grafana/grafana#121843.
Related to grafana/grafana-prometheus-datasource#141.

## Testing

- `yarn workspace @grafana/prometheus test:ci`
- `yarn workspace @grafana/prometheus typecheck`

Note: the full Jest run passes (`918` tests), but the local run logs existing jsdom `MessageChannel is not defined` console errors from unrelated query builder interaction tests.