### PR TITLE
Prometheus: Associate query builder param label with its input for a11y

### DIFF
--- a/.changeset/quiet-labels-speak.md
+++ b/.changeset/quiet-labels-speak.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Query builder: associate each parameter label with its input so screen readers announce the field (a11y)

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
 import { css, cx } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as React from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type TimeRange } from '@grafana/data';
@@ -49,7 +49,6 @@ export function OperationEditor({
   const styles = useStyles2(getStyles);
   const def = queryModeller.getOperationDef(operation.id);
   const shouldFlash = useFlash(flash);
-  const id = useId();
 
   if (!def) {
     return (
@@ -90,7 +89,7 @@ export function OperationEditor({
       <div className={styles.paramRow} key={`${paramIndex}-1`}>
         {!paramDef.hideName && (
           <div className={styles.paramName}>
-            <label htmlFor={getOperationParamId(id, paramIndex)}>{paramDef.name}</label>
+            <label htmlFor={getOperationParamId(`${operation.id}.${index}`, paramIndex)}>{paramDef.name}</label>
             {paramDef.description && (
               <Tooltip placement="top" content={paramDef.description} theme="info">
                 <Icon name="info-circle" size="sm" className={styles.infoIcon} />
@@ -104,7 +103,7 @@ export function OperationEditor({
               paramDef={paramDef}
               value={operation.params[paramIndex]}
               index={paramIndex}
-              operationId={operation.id}
+              operationId={`${operation.id}.${index}`}
               query={query}
               datasource={datasource}
               timeRange={timeRange}

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
 import { css, cx } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import * as React from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type TimeRange } from '@grafana/data';
@@ -49,6 +49,10 @@ export function OperationEditor({
   const styles = useStyles2(getStyles);
   const def = queryModeller.getOperationDef(operation.id);
   const shouldFlash = useFlash(flash);
+  // useId is namespaced per editor instance, so labels and inputs in this
+  // editor share an id while sibling OperationLists (e.g. multiple Prometheus
+  // queries on the same panel) get distinct ids and do not collide in the DOM.
+  const operationParamScope = useId();
 
   if (!def) {
     return (
@@ -89,7 +93,7 @@ export function OperationEditor({
       <div className={styles.paramRow} key={`${paramIndex}-1`}>
         {!paramDef.hideName && (
           <div className={styles.paramName}>
-            <label htmlFor={getOperationParamId(`${operation.id}.${index}`, paramIndex)}>{paramDef.name}</label>
+            <label htmlFor={getOperationParamId(operationParamScope, paramIndex)}>{paramDef.name}</label>
             {paramDef.description && (
               <Tooltip placement="top" content={paramDef.description} theme="info">
                 <Icon name="info-circle" size="sm" className={styles.infoIcon} />
@@ -103,7 +107,7 @@ export function OperationEditor({
               paramDef={paramDef}
               value={operation.params[paramIndex]}
               index={paramIndex}
-              operationId={`${operation.id}.${index}`}
+              operationId={operationParamScope}
               query={query}
               datasource={datasource}
               timeRange={timeRange}

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
@@ -49,6 +49,32 @@ describe('OperationList', () => {
     });
   });
 
+  it('associates each param label with its input so screen readers announce it', () => {
+    // Regression for https://github.com/grafana/grafana/issues/66347 — the <label>
+    // used a useId-derived id while the editors used operation.id, so every param
+    // label was an orphan and Prometheus query builder fields had no accessible name.
+    setup();
+    // Rate has a Range param — the label "Range" must be linked to its combo box input.
+    expect(screen.getByLabelText('Range').tagName).toBe('INPUT');
+  });
+
+  it('gives each instance of a duplicated operation a distinct input id', () => {
+    // The id includes the operation's index so two `rate` operations don't
+    // produce duplicate `operations.rate.param.0` ids (which would confuse
+    // screen readers and collide in the DOM).
+    setup({
+      metric: 'random_metric',
+      labels: [{ label: 'instance', op: '=', value: 'localhost:9090' }],
+      operations: [
+        { id: 'rate', params: ['auto'] },
+        { id: 'rate', params: ['$__rate_interval'] },
+      ],
+    });
+    const rangeInputs = screen.getAllByLabelText('Range');
+    expect(rangeInputs).toHaveLength(2);
+    expect(rangeInputs[0].id).not.toBe(rangeInputs[1].id);
+  });
+
   it('adds an operation', async () => {
     const { onChange } = setup();
     await addOperationInQueryBuilder('Aggregations', 'Min');

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
@@ -59,9 +59,9 @@ describe('OperationList', () => {
   });
 
   it('gives each instance of a duplicated operation a distinct input id', () => {
-    // The id includes the operation's index so two `rate` operations don't
-    // produce duplicate `operations.rate.param.0` ids (which would confuse
-    // screen readers and collide in the DOM).
+    // Each OperationEditor uses its own useId() value as the param-id prefix,
+    // so two `rate` operations don't produce duplicate ids (which would
+    // confuse screen readers and collide in the DOM).
     setup({
       metric: 'random_metric',
       labels: [{ label: 'instance', op: '=', value: 'localhost:9090' }],
@@ -73,6 +73,28 @@ describe('OperationList', () => {
     const rangeInputs = screen.getAllByLabelText('Range');
     expect(rangeInputs).toHaveLength(2);
     expect(rangeInputs[0].id).not.toBe(rangeInputs[1].id);
+  });
+
+  it('keeps ids unique across multiple OperationLists rendered on the same page', () => {
+    // Multiple Prometheus queries on a single Grafana panel each render their
+    // own OperationList; if both contain `rate` at index 0 the param ids must
+    // still be distinct, otherwise the second list's <label htmlFor> binds to
+    // the first list's input and screen readers announce the wrong field.
+    const props = makeProps();
+    const query: PromVisualQuery = {
+      metric: 'random_metric',
+      labels: [{ label: 'instance', op: '=', value: 'localhost:9090' }],
+      operations: [{ id: 'rate', params: ['auto'] }],
+    };
+    render(
+      <>
+        <OperationList {...props} query={query} />
+        <OperationList {...props} query={query} />
+      </>
+    );
+    const rangeInputs = screen.getAllByLabelText('Range');
+    expect(rangeInputs).toHaveLength(2);
+    expect(new Set(rangeInputs.map((input) => input.id)).size).toBe(2);
   });
 
   it('adds an operation', async () => {
@@ -90,9 +112,9 @@ describe('OperationList', () => {
   });
 });
 
-function setup(query: PromVisualQuery = defaultQuery) {
+function makeProps() {
   const languageProvider = new EmptyLanguageProviderMock() as unknown as PrometheusLanguageProviderInterface;
-  const props = {
+  return {
     datasource: new PrometheusDatasource(
       {
         url: '',
@@ -107,7 +129,10 @@ function setup(query: PromVisualQuery = defaultQuery) {
     queryModeller: promQueryModeller,
     timeRange: getMockTimeRange(),
   };
+}
 
+function setup(query: PromVisualQuery = defaultQuery) {
+  const props = makeProps();
   render(<OperationList {...props} query={query} />);
   return props;
 }

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
@@ -150,7 +150,7 @@ function SelectInputParamEditor({
   return (
     <Stack gap={0.5} direction="row" alignItems="center">
       <Select
-        id={getOperationParamId(operationId, index)}
+        inputId={getOperationParamId(operationId, index)}
         value={valueOption}
         options={selectOptions}
         placeholder={paramDef.placeholder}


### PR DESCRIPTION
## What this does

Fixes a long-standing accessibility issue in the Prometheus query builder where every parameter `<label>` was an orphan. The label used an htmlFor derived from `useId()` while the editors used `operation.id`, so the two never matched and screen readers announced each field with no accessible name. WCAG 3.3.2 / 4.1.2 Level A.

This is a port of [grafana/grafana#122985](https://github.com/grafana/grafana/pull/122985), which @ashharrison90 reviewed favourably ("i think the change looks good") and then pointed out that the code had since been extracted into this repo — so the fix needs to land here.

## The change

- `OperationEditor.tsx` — drop `useId()`, use `${operation.id}.${index}` so duplicate operations of the same type still get distinct ids and the label points at the right input.
- `OperationParamEditorRegistry.tsx` — switch `Select` from `id` (lands on the wrapper) to `inputId` (lands on the actual `<input>`).
- `OperationList.test.tsx` — two regression tests:
  - `getByLabelText('Range')` finds an `INPUT` element (label association).
  - Two `rate` operations produce distinct param ids.

## Verification

```
$ yarn workspace @grafana/prometheus jest packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
PASS src/querybuilder/shared/OperationList.test.tsx
  ✓ associates each param label with its input so screen readers announce it
  ✓ gives each instance of a duplicated operation a distinct input id
  Tests: 5 passed, 5 total

$ yarn workspace @grafana/prometheus typecheck    # clean
$ yarn workspace @grafana/prometheus lint         # clean
```

## Refs

- Issue: grafana/grafana#66347 (still tracked there)
- Original PR: grafana/grafana#122985 (will be closed once this is open)
- Migration PR that moved the code: grafana/grafana#123035
