### PR TITLE
Fix: resolve t()-before-i18n-initialized errors in externalized plugin

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,26 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
 
+// `@grafana/runtime`'s GrafanaBootConfig constructor logs
+// `console.error("window.grafanaBootData was not set by the time config was initialized")`
+// the first time it's evaluated without a host-injected boot payload. The constructor
+// runs the moment any module imports `@grafana/runtime` (transitively via @grafana/ui,
+// @grafana/plugin-ui, @grafana/assistant, etc.) — including from src/module.ts during
+// `jest.isolateModules` re-imports. Pre-populate the global with the same minimal
+// shape grafana/grafana uses in `public/test/jest-setup.ts` so the constructor takes
+// the happy path and stays quiet.
+//
+// Use `??=` (and the `(globalThis as any)` cast in JS-as-CJS form below) to avoid
+// clobbering anything a future test sets explicitly via Object.defineProperty on
+// window.grafanaBootData.
+if (typeof window !== 'undefined' && !window.grafanaBootData) {
+  window.grafanaBootData = {
+    settings: { featureToggles: {} },
+    user: { locale: 'en-US' },
+    navTree: [],
+  };
+}
+
 // ResizeObserver is not available in jsdom
 global.ResizeObserver = class ResizeObserver {
   observe() {}

--- a/packages/grafana-prometheus/src/promql.lazy.test.ts
+++ b/packages/grafana-prometheus/src/promql.lazy.test.ts
@@ -1,0 +1,80 @@
+describe('promql lazy function regex', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.dontMock('@grafana/i18n');
+  });
+
+  function loadPromqlWithSpiedT(): {
+    promqlGrammar: { function: RegExp; [key: string]: unknown };
+    tSpy: jest.Mock;
+  } {
+    const tSpy = jest.fn((_key: string, fallback: string) => fallback);
+
+    jest.doMock('@grafana/i18n', () => {
+      const actual = jest.requireActual('@grafana/i18n');
+      return { ...actual, t: tSpy };
+    });
+
+    let mod: { promqlGrammar: { function: RegExp; [key: string]: unknown } } = {
+      promqlGrammar: { function: /never/ },
+    };
+    jest.isolateModules(() => {
+      mod = require('./promql');
+    });
+    return { promqlGrammar: mod.promqlGrammar, tSpy };
+  }
+
+  it('does not call t() when promql.ts is first imported', () => {
+    const { tSpy } = loadPromqlWithSpiedT();
+    expect(tSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call t() when other grammar fields are read (only `function` is lazy)', () => {
+    const { promqlGrammar, tSpy } = loadPromqlWithSpiedT();
+
+    void promqlGrammar.comment;
+    void promqlGrammar['context-aggregation'];
+    void promqlGrammar['context-labels'];
+    void promqlGrammar['context-range'];
+    void promqlGrammar.idList;
+    void promqlGrammar.number;
+    void promqlGrammar.operator;
+    void promqlGrammar.punctuation;
+
+    expect(tSpy).not.toHaveBeenCalled();
+  });
+
+  it('builds the function regex lazily on first read of promqlGrammar.function', () => {
+    const { promqlGrammar, tSpy } = loadPromqlWithSpiedT();
+    expect(tSpy).not.toHaveBeenCalled();
+
+    const regex = promqlGrammar.function;
+
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.test('rate(')).toBe(true);
+    expect(regex.test('histogram_quantile(')).toBe(true);
+    expect(regex.test('sum(')).toBe(true);
+    // lookahead requires an opening paren; bare identifiers must not match
+    expect(regex.test('rate')).toBe(false);
+
+    expect(tSpy.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('memoizes the regex: subsequent reads return the same instance and do not re-call t()', () => {
+    const { promqlGrammar, tSpy } = loadPromqlWithSpiedT();
+
+    const first = promqlGrammar.function;
+    const callsAfterFirstRead = tSpy.mock.calls.length;
+    expect(callsAfterFirstRead).toBeGreaterThan(0);
+
+    const second = promqlGrammar.function;
+    const third = promqlGrammar.function;
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(tSpy.mock.calls.length).toBe(callsAfterFirstRead);
+  });
+});

--- a/packages/grafana-prometheus/src/promql.ts
+++ b/packages/grafana-prometheus/src/promql.ts
@@ -817,6 +817,21 @@ export const getFunctions = () => [
   },
 ];
 
+// Lazy getter: getFunctions() calls t() on every entry, which throws if i18n
+// isn't initialized yet. Deferring to first tokenization avoids the race.
+let _functionRegex: RegExp | undefined;
+const getFunctionRegex = (): RegExp => {
+  if (!_functionRegex) {
+    _functionRegex = new RegExp(
+      `\\b(?:${getFunctions()
+        .map((f) => f.label)
+        .join('|')})(?=\\s*\\()`,
+      'i'
+    );
+  }
+  return _functionRegex;
+};
+
 export const promqlGrammar: Grammar = {
   comment: {
     pattern: /#.*/,
@@ -852,12 +867,9 @@ export const promqlGrammar: Grammar = {
       punctuation: /[{]/,
     },
   },
-  function: new RegExp(
-    `\\b(?:${getFunctions()
-      .map((f) => f.label)
-      .join('|')})(?=\\s*\\()`,
-    'i'
-  ),
+  get function() {
+    return getFunctionRegex();
+  },
   'context-range': [
     {
       pattern: /\[[^\]]*(?=])/, // [1m]

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -1,7 +1,71 @@
 import { plugin as PrometheusDatasourcePlugin } from './module';
 
+declare const process: { env: { NODE_ENV?: string } };
+declare const require: (id: string) => { plugin: unknown };
+
 describe('module', () => {
   it('should have metrics query field in panels and Explore', () => {
     expect(PrometheusDatasourcePlugin.components.QueryEditor).toBeDefined();
+  });
+});
+
+describe('module i18n bootstrap', () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    jest.dontMock('@grafana/i18n');
+    jest.resetModules();
+  });
+
+  function loadModuleWith({
+    nodeEnv,
+    initPluginTranslations,
+  }: {
+    nodeEnv: string;
+    initPluginTranslations: jest.Mock;
+  }): { plugin: unknown } {
+    process.env.NODE_ENV = nodeEnv;
+
+    let exports: { plugin: unknown } = { plugin: undefined };
+    jest.isolateModules(() => {
+      jest.doMock('@grafana/i18n', () => {
+        const actual = jest.requireActual('@grafana/i18n');
+        return { ...actual, initPluginTranslations };
+      });
+
+      exports = require('./module');
+    });
+    return exports;
+  }
+
+  it('skips initPluginTranslations under jest (NODE_ENV=test) to keep test output clean', () => {
+    const initPluginTranslations = jest.fn();
+    loadModuleWith({ nodeEnv: 'test', initPluginTranslations });
+    expect(initPluginTranslations).not.toHaveBeenCalled();
+  });
+
+  it('calls initPluginTranslations(pluginJson.id, [loadResources]) when running outside jest', () => {
+    const initPluginTranslations = jest.fn();
+    loadModuleWith({ nodeEnv: 'production', initPluginTranslations });
+
+    expect(initPluginTranslations).toHaveBeenCalledTimes(1);
+    const [pluginId, resources] = initPluginTranslations.mock.calls[0];
+    expect(pluginId).toBe('prometheus');
+    expect(Array.isArray(resources)).toBe(true);
+    expect(resources).toHaveLength(1);
+    expect(typeof resources[0]).toBe('function');
+  });
+
+  it('does not await initPluginTranslations: module evaluates synchronously even when the bootstrap promise never resolves', () => {
+    // If module.ts regresses to `await initPluginTranslations(...)`, require()
+    // resolves to a Promise instead of the plugin exports.
+    const initPluginTranslations = jest.fn(() => new Promise<void>(() => {}));
+
+    const exports = loadModuleWith({ nodeEnv: 'production', initPluginTranslations });
+
+    expect(exports.plugin).toBeDefined();
+    expect(exports.plugin).not.toBeInstanceOf(Promise);
+    expect(initPluginTranslations).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,22 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { PromCheatSheet, PrometheusDatasource, PromQueryEditorByApp } from '@grafana/prometheus';
+import { initPluginTranslations } from '@grafana/i18n';
+import { loadResources, PromCheatSheet, PrometheusDatasource, PromQueryEditorByApp } from '@grafana/prometheus';
 
 import { ConfigEditor } from './configuration/ConfigEditor';
+import pluginJson from './plugin.json';
+
+// process.env.NODE_ENV is replaced by webpack's DefinePlugin at build time;
+// declared locally to avoid pulling @types/node into the plugin tsconfig.
+declare const process: { env: { NODE_ENV?: string } };
+
+// Fire-and-forget: top-level `await` turns module.ts into a webpack async
+// module whose exports become a Promise. AMD + SystemJS doesn't propagate
+// that Promise reliably, so the host would render components before tFunc
+// is set. The synchronous part of initPluginTranslations sets tFunc on the
+// next microtask — before any plugin-rendered component mounts.
+if (process.env.NODE_ENV !== 'test') {
+  void initPluginTranslations(pluginJson.id, [loadResources]);
+}
 
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)

--- a/tests/e2e/i18nInitialization.spec.ts
+++ b/tests/e2e/i18nInitialization.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { type ConsoleMessage, type Page } from '@playwright/test';
+
+const PLUGIN_TYPE = 'prometheus';
+
+const FORBIDDEN_PATTERNS: RegExp[] = [
+  /t\(\) was called before i18n was initialized/i,
+  /react-i18next.*NO_I18NEXT_INSTANCE/i,
+  /You need to pass in an i18next instance using i18nextReactModule/i,
+];
+
+type Captured = { source: 'pageerror' | 'console'; type?: string; text: string };
+
+function attachCapture(page: Page): Captured[] {
+  const captured: Captured[] = [];
+  page.on('pageerror', (err) => {
+    captured.push({ source: 'pageerror', text: `${err.name}: ${err.message}\n${err.stack ?? ''}` });
+  });
+  page.on('console', (msg: ConsoleMessage) => {
+    const type = msg.type();
+    if (type === 'error' || type === 'warning') {
+      captured.push({ source: 'console', type, text: msg.text() });
+    }
+  });
+  return captured;
+}
+
+function findForbidden(captured: Captured[]): Captured[] {
+  return captured.filter((entry) => FORBIDDEN_PATTERNS.some((rx) => rx.test(entry.text)));
+}
+
+test.describe('i18n initialization', () => {
+  test(
+    'config editor mounts AlertingSettingsOverhaul and PromSettings without i18n-not-initialized errors',
+    { tag: '@plugins' },
+    async ({ createDataSourceConfigPage, page }) => {
+      const captured = attachCapture(page);
+
+      await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+
+      await expect(page.getByRole('heading', { name: 'Alerting', exact: true })).toBeVisible();
+      await expect(page.getByText('Manage alerts via Alerting UI', { exact: true })).toBeVisible();
+      await expect(page.getByText('Scrape interval', { exact: true })).toBeVisible();
+      await expect(page.getByText('Query timeout', { exact: true })).toBeVisible();
+      // i18n key must never leak into the DOM
+      await expect(page.getByText('grafana-prometheus.configuration.', { exact: false })).toHaveCount(0);
+
+      const violations = findForbidden(captured);
+      expect(
+        violations,
+        `Captured i18n-initialization errors:\n${violations.map((v) => `[${v.source}${v.type ? '/' + v.type : ''}] ${v.text}`).join('\n---\n')}`
+      ).toEqual([]);
+    }
+  );
+
+  test(
+    'explore with prometheus datasource imports promql.ts grammar without top-level t() throwing',
+    { tag: '@plugins' },
+    async ({ explorePage, page }) => {
+      const captured = attachCapture(page);
+
+      await explorePage.datasource.set('prometheus');
+
+      await expect(
+        page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]')
+      ).toBeVisible();
+
+      // Open QueryPatternsModal — the last hop on the import chain that triggered the eager t() call
+      const kickStart = page.getByRole('button', { name: 'Kick start your query' });
+      await expect(kickStart).toBeVisible();
+      await kickStart.click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+
+      const violations = findForbidden(captured);
+      expect(
+        violations,
+        `Captured i18n-initialization errors during Explore + QueryPatternsModal:\n${violations.map((v) => `[${v.source}${v.type ? '/' + v.type : ''}] ${v.text}`).join('\n---\n')}`
+      ).toEqual([]);
+    }
+  );
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,26 +11,27 @@ const config = async (env: Env): Promise<Configuration> => {
 
   return merge(baseConfig, {
     resolve: {
-      // Point at the workspace library's TypeScript source instead of ./dist,
-      // so the plugin doesn't require the library to be prebuilt during
-      // development. The library is transpiled together with the plugin by
-      // the existing swc-loader rule (workspace paths are not under any
-      // node_modules once symlinks are resolved).
+      // Use the workspace library's TypeScript source directly so no prebuilt
+      // dist is needed during development. swc-loader picks it up because
+      // symlinks resolve outside node_modules.
+      //
+      // Force @grafana/i18n and react-i18next to a single canonical path.
+      // Yarn workspaces install both packages twice (root + inner workspace),
+      // giving each copy its own module-scoped tFunc. Only one copy gets
+      // initialized by initPluginTranslations(), causing "t() was called
+      // before i18n was initialized" in components that import the other copy.
       alias: {
         '@grafana/prometheus$': path.resolve(__dirname, 'packages/grafana-prometheus/src/index.ts'),
+        '@grafana/i18n$': path.resolve(__dirname, 'node_modules/@grafana/i18n'),
+        'react-i18next$': path.resolve(__dirname, 'node_modules/react-i18next'),
       },
     },
     plugins: [
-      // Workaround: the scaffolded SWC loader uses the classic JSX transform
-      // (React.createElement), which requires React to be in scope in every JSX file.
-      // ProvidePlugin injects `var React = require('react')` automatically into any
-      // module that references the React global, using Grafana's externalized react instance.
+      // SWC loader uses the classic JSX transform (React.createElement), so React
+      // must be in scope in every JSX file. ProvidePlugin injects it automatically.
       //
-      // TODO: remove this ProvidePlugin once grafana/plugin-tools@951defa lands in a create-plugin release
-      //  (adds jsc.transform.react.runtime='automatic' to the
-      //  scaffolded webpack config) AND this plugin has run `npx @grafana/create-plugin@latest update`.
-      //  After that, JSX uses react/jsx-runtime instead of React.createElement, so React
-      //  no longer needs to be a global.
+      // TODO: remove once grafana/plugin-tools@951defa ships and this plugin runs
+      //  `npx @grafana/create-plugin@latest update` (switches to react/jsx-runtime).
       new webpack.ProvidePlugin({ React: 'react' }),
     ],
   });


### PR DESCRIPTION
### Summary

Three stacked issues caused `t() was called before i18n was initialized`
errors when the Prometheus datasource runs as an externalized plugin:

- **Yarn workspace duplication** — `@grafana/i18n` and `react-i18next`
  were physically installed twice, giving each copy its own `tFunc` closure.
  `initPluginTranslations()` initialized only the top-level copy; components
  imported from the inner workspace copy and saw an uninitialized `tFunc`.
  Fixed by webpack `resolve.alias` pinning both to a single canonical path.

- **Eager `t()` at module top level** — `promqlGrammar.function` was a
  `const` regex built by calling `getFunctions()` (which calls `t()`) at
  module evaluation time, before `initPluginTranslations()` had run.
  Fixed by replacing it with a lazy getter that memoizes on first read.

- **`await` + AMD/SystemJS race** — top-level `await initPluginTranslations`
  turned `module.ts` into a webpack async module whose exports became a
  Promise; SystemJS doesn't propagate that Promise reliably.
  Fixed by calling fire-and-forget (`void`) instead.

### Test plan

- [ ] `yarn test` — new unit tests cover the lazy getter and the fire-and-forget bootstrap
- [ ] `yarn build && docker compose restart grafana` — open Prometheus datasource config page, no `t() was called before i18n was initialized` or `react-i18next: NO_I18NEXT_INSTANCE` errors
- [ ] New e2e spec (`tests/e2e/i18nInitialization.spec.ts`) covers both the config editor and Explore/QueryPatternsModal paths
