### PR TITLE
fix: add accessibility support for Prometheus label filter operator dropdown

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
@@ -132,6 +132,7 @@ export function LabelFilterItem({
 
         {/* Operator select i.e.   = =~ != !~   */}
         <Select
+          aria-label={t('grafana-prometheus.querybuilder.label-filter-item.aria-label-operator', 'Label filter operator')}
           data-testid={selectors.components.QueryBuilder.matchOperatorSelect}
           className="query-segment-operator"
           value={toOption(item.op ?? defaultOp)}
@@ -216,8 +217,8 @@ export function LabelFilterItem({
 }
 
 const operators = [
-  { label: '=', value: '=', isMultiValue: false },
-  { label: '!=', value: '!=', isMultiValue: false },
-  { label: '=~', value: '=~', isMultiValue: true },
-  { label: '!~', value: '!~', isMultiValue: true },
+  { label: '=', value: '=', isMultiValue: false, description: 'Equals' },
+  { label: '!=', value: '!=', isMultiValue: false, description: 'Not equals' },
+  { label: '=~', value: '=~', isMultiValue: true, description: 'Regex match' },
+  { label: '!~', value: '!~', isMultiValue: true, description: 'Not regex match' },
 ];


### PR DESCRIPTION
## Summary

Fixes grafana/grafana#67028

The Prometheus query editor's label filter operator dropdown exposes raw symbols (`=`, `!=`, `=~`, `!~`) to screen readers instead of meaningful text. This makes it difficult for visually impaired users to understand what operator is selected.

## Changes

1. **Added `aria-label` to the operator `<Select>` component** - Screen readers will now announce "Label filter operator" when the dropdown receives focus.

2. **Added `description` to each operator option** - Each operator now includes a human-readable description:
   - `=` -> "Equals"
   - `!=` -> "Not equals"
   - `=~` -> "Regex match"
   - `!~` -> "Not regex match"

## Testing

- [x] Verified that the `Select` component from `@grafana/ui` supports the `aria-label` prop
- [x] Verified that `SelectableValue` from `@grafana/data` supports the `description` field
- [x] Changes are backward compatible - no breaking changes to the API

## Screenshots

The visual appearance of the dropdown remains unchanged. Only the accessibility attributes are modified.
