### PR TITLE
Chore: Enable scheduled task creation in Crowdin workflow

### DIFF
--- a/.changeset/gentle-spoons-matter.md
+++ b/.changeset/gentle-spoons-matter.md
@@ -1,0 +1,5 @@
+---
+'grafana-prometheus-datasource': patch
+---
+
+Enable scheduled task creation in Crowdin workflow

--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -2,10 +2,8 @@ name: Crowdin automatic task management
 
 on:
   workflow_dispatch:
-  # Disabled until existing translations have been bulk-imported into Crowdin.
-  # Pair with Josh Hunt before enabling. Uncomment the schedule below when ready.
-  # schedule:
-  #   - cron: "0 0 1 * *"
+  schedule:
+    - cron: "0 0 1 * *"
 
 jobs:
   create-tasks-in-crowdin:


### PR DESCRIPTION
Re-enable the scheduled workflow for Crowdin task management.