### PR TITLE
fix(prometheus): use lezer tree instead of greedy regex for range duration

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
@@ -255,6 +255,29 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses rate query with [ in label filter value', () => {
+    expect(
+      buildVisualQueryFromString('rate(metric{label=~"value[0-9]"}[5m])')
+    ).toEqual(
+      noErrors({
+        metric: 'metric',
+        labels: [
+          {
+            op: '=~',
+            value: 'value[0-9]',
+            label: 'label',
+          },
+        ],
+        operations: [
+          {
+            id: 'rate',
+            params: ['5m'],
+          },
+        ],
+      })
+    );
+  });
+
   it('parses query with nested query and interval variable', () => {
     expect(
       buildVisualQueryFromString(

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -15,6 +15,7 @@ import {
   QuotedLabelName,
   MatchingModifierClause,
   MatchOp,
+  MatrixSelector,
   NumberDurationLiteral,
   On,
   ParenExpr,
@@ -251,12 +252,16 @@ function handleFunction(expr: string, node: SyntaxNode, context: Context) {
   //   the query model.
   // - it is easier to handle template variables this way as template variable is an error for the parser
   if (rangeFunctions.includes(funcName) || funcName.endsWith('_over_time')) {
-    let match = getString(expr, node).match(/\[(.+)\]/);
-    if (match?.[1]) {
-      interval = match[1];
-      // We were replaced the builtin variables to prevent errors
-      // Here we return those back
-      params.push(returnBuiltInVariable(match[1]));
+    // Walk the syntax tree to find the range duration instead of using regex,
+    // since greedy /\[(.+)\]/ incorrectly matches '[' characters inside label values
+    // e.g. rate(metric{label=~"value[0-9]"}[5m]) would capture '0-9]"}[5m' instead of '5m'
+    const selectorNode = body?.getChild(MatrixSelector);
+    if (selectorNode) {
+      const durationNode = selectorNode.getChild(NumberDurationLiteral);
+      if (durationNode) {
+        interval = getString(expr, durationNode);
+        params.push(returnBuiltInVariable(interval));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes grafana/grafana-prometheus-datasource#97

The PromQL query builder used the greedy regex `/\[(.+)\]/` to extract range duration (e.g., `5m` in `rate(metric[5m])`) from function call text. This broke when label filter values contained `[` characters, because the regex matched from the first `[` (inside the label value) to the last `]` (the duration bracket).

## Root Cause

`parsing.ts` line 254: `getString(expr, node).match(/\[(.+)\]/)` extracts the full function call text and applies a greedy regex. For a query like `rate(metric{label=~"value[0-9]"}[5m])`, the regex captures `0-9]"}[5m` instead of `5m`.

## Fix

Replace the regex with lezer syntax tree traversal. The `FunctionCallBody` already has a parsed `MatrixSelector` child node. From the `MatrixSelector`, extract the `NumberDurationLiteral` child to get the exact duration text.

- Import `MatrixSelector` from `@prometheus-io/lezer-promql`
- Traverse `body.getChild(MatrixSelector)` → `getChild(NumberDurationLiteral)` 
- Extract duration using the existing `getString(expr, durationNode)` pattern

## Changes

- `packages/grafana-prometheus/src/querybuilder/parsing.ts`: Replace greedy regex with lezer tree traversal (`+11 -6` lines)
- `packages/grafana-prometheus/src/querybuilder/parsing.test.ts`: Add test for `[` in label filter values (`+23 -0` lines)

## Testing

- **rate() with `[` in label value**: `rate(metric{label=~"value[0-9]"}[5m])` → correctly parses duration as `5m` ✅
- **rate() without `[` in label (existing test preserved)**: `rate(counters_logins{app="frontend"}[5m])` → still works ✅
- **Nested query with interval variable (existing test preserved)**: `avg(rate(...)[$__rate_interval])` → still works ✅