### PR TITLE
Fix: Keep Kick start your query button visible while typing in a new query editor

### DIFF
--- a/.changeset/kickstart-button-visibility.md
+++ b/.changeset/kickstart-button-visibility.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Keep the "Kick start your query" button visible while typing in a new query editor. The button is now hidden only when the editor opens with an existing query (e.g. loaded from a saved panel or dashboard).

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.test.tsx
@@ -197,6 +197,33 @@ describe('PromQueryEditorSelector', () => {
     });
   });
 
+  it('shows the Kick start your query button for a new query editor', async () => {
+    renderWithProps({ expr: '' });
+    expect(await screen.findByRole('button', { name: /kick start your query/i })).toBeInTheDocument();
+  });
+
+  it('hides the Kick start your query button when the editor opens with an existing query', async () => {
+    renderWithProps({ expr: 'rate(http_requests_total[5m])' });
+    expect(screen.queryByRole('button', { name: /kick start your query/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the Kick start your query button visible after typing in a new query editor', async () => {
+    const { rerender } = renderWithProps({ expr: '' });
+    expect(await screen.findByRole('button', { name: /kick start your query/i })).toBeInTheDocument();
+
+    rerender(
+      <PromQueryEditorSelector
+        {...defaultProps}
+        query={{
+          refId: 'A',
+          expr: 'rat',
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /kick start your query/i })).toBeInTheDocument();
+  });
+
   it('parses query when changing to builder mode', async () => {
     const { rerender } = renderWithProps({
       refId: 'A',

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -1,6 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
 import { isEqual } from 'lodash';
-import { memo, type SyntheticEvent, useCallback, useEffect, useState } from 'react';
+import { memo, type SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { QueryWithAssistantButton } from '@grafana/assistant';
 import { CoreApp, LoadingState } from '@grafana/data';
@@ -42,6 +42,8 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
   const [queryPatternsModalOpen, setQueryPatternsModalOpen] = useState(false);
   const [dataIsStale, setDataIsStale] = useState(false);
   const { flag: explain, setFlag: setExplain } = useFlag(promQueryEditorExplainKey);
+  // Captured once on mount so typing in a new editor doesn't hide the Kickstart button.
+  const openedWithExistingQueryRef = useRef(Boolean(props.query.expr));
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.
@@ -133,7 +135,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
             app={app}
           />
         )}
-        {!query.expr && (
+        {!openedWithExistingQueryRef.current && (
           <Button
             data-testid={selectors.components.QueryBuilder.queryPatterns}
             variant="secondary"


### PR DESCRIPTION
## Summary

The "Kick start your query" button in the Prometheus query editor disappears as soon as the user starts typing in a new editor. The button should only hide when the editor opens with an existing (saved) query.

- Capture `Boolean(props.query.expr)` on mount via a `useRef` and gate the button on that initial value.
- New editors keep the button visible regardless of typing; editors loaded with a saved query continue to hide it.
- Adds three unit tests covering the new behavior in `PromQueryEditorSelector.test.tsx`.

Fixes grafana/grafana-prometheus-datasource#108 (restores the intent of grafana/grafana#113762 without the regression).

## Test plan

- [x] `jest` — all 918 `@grafana/prometheus` tests pass, including 3 new cases in `PromQueryEditorSelector.test.tsx`:
  - shows the Kick start your query button for a new query editor
  - hides the Kick start your query button when the editor opens with an existing query
  - keeps the Kick start your query button visible after typing in a new query editor
- [x] `yarn typecheck` passes
- [ ] Manual: open a new Prometheus query editor, type a partial query — button should remain visible. Open a saved dashboard panel with an existing Prometheus query — button should be hidden.