### PR TITLE
Add hover titles for label filter operators

### DIFF
--- a/.changeset/green-kiwis-grab.md
+++ b/.changeset/green-kiwis-grab.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add hover titles for label filter operators

--- a/packages/grafana-prometheus/src/locales/en-US/grafana-prometheus.json
+++ b/packages/grafana-prometheus/src/locales/en-US/grafana-prometheus.json
@@ -346,7 +346,12 @@
         }
       },
       "label-filter-item": {
+        "aria-label-operator": "Label filter operator",
         "aria-label-remove": "Remove {{name}}",
+        "operator-equals": "Equals",
+        "operator-not-equals": "Not equals",
+        "operator-not-regex-match": "Not regex match",
+        "operator-regex-match": "Regex match",
         "placeholder-select-label": "Select label",
         "placeholder-select-value": "Select value"
       },

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
@@ -36,6 +36,7 @@ export function LabelFilterItem({
   getLabelValuesAutofillSuggestions,
   debounceDuration,
 }: LabelFilterItemProps) {
+  const operators = getOperatorOptions();
   const [state, setState] = useState<{
     labelNames?: SelectableValue[];
     labelValues?: SelectableValue[];
@@ -50,7 +51,7 @@ export function LabelFilterItem({
   const [allLabels, setAllLabels] = useState<SelectableValue[]>([]);
 
   const isMultiSelect = (operator = item.op) => {
-    return operators.find((op) => op.label === operator)?.isMultiValue;
+    return operators.find((op) => op.value === operator)?.isMultiValue;
   };
 
   const getSelectOptionsFromString = (item?: string): string[] => {
@@ -132,11 +133,17 @@ export function LabelFilterItem({
 
         {/* Operator select i.e.   = =~ != !~   */}
         <Select
+          aria-label={t(
+            'grafana-prometheus.querybuilder.label-filter-item.aria-label-operator',
+            'Label filter operator'
+          )}
           data-testid={selectors.components.QueryBuilder.matchOperatorSelect}
           className="query-segment-operator"
-          value={toOption(item.op ?? defaultOp)}
+          value={item.op ?? defaultOp}
           options={operators}
           width="auto"
+          getOptionLabel={getOperatorAccessibleLabel}
+          formatOptionLabel={(operator) => operator.label ?? ''}
           onChange={(change) => {
             if (change.value != null) {
               onChange({
@@ -215,9 +222,39 @@ export function LabelFilterItem({
   );
 }
 
-const operators = [
-  { label: '=', value: '=', isMultiValue: false },
-  { label: '!=', value: '!=', isMultiValue: false },
-  { label: '=~', value: '=~', isMultiValue: true },
-  { label: '!~', value: '!~', isMultiValue: true },
+type OperatorOption = SelectableValue<string> & { isMultiValue: boolean };
+
+const getOperatorOptions = (): OperatorOption[] => [
+  {
+    label: '=',
+    ariaLabel: t('grafana-prometheus.querybuilder.label-filter-item.operator-equals', 'Equals'),
+    title: t('grafana-prometheus.querybuilder.label-filter-item.operator-equals', 'Equals'),
+    value: '=',
+    isMultiValue: false,
+  },
+  {
+    label: '!=',
+    ariaLabel: t('grafana-prometheus.querybuilder.label-filter-item.operator-not-equals', 'Not equals'),
+    title: t('grafana-prometheus.querybuilder.label-filter-item.operator-not-equals', 'Not equals'),
+    value: '!=',
+    isMultiValue: false,
+  },
+  {
+    label: '=~',
+    ariaLabel: t('grafana-prometheus.querybuilder.label-filter-item.operator-regex-match', 'Regex match'),
+    title: t('grafana-prometheus.querybuilder.label-filter-item.operator-regex-match', 'Regex match'),
+    value: '=~',
+    isMultiValue: true,
+  },
+  {
+    label: '!~',
+    ariaLabel: t('grafana-prometheus.querybuilder.label-filter-item.operator-not-regex-match', 'Not regex match'),
+    title: t('grafana-prometheus.querybuilder.label-filter-item.operator-not-regex-match', 'Not regex match'),
+    value: '!~',
+    isMultiValue: true,
+  },
 ];
+
+const getOperatorAccessibleLabel = (operator: SelectableValue<string>) => {
+  return operator.ariaLabel ?? operator.label ?? String(operator.value ?? '');
+};

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.test.tsx
@@ -143,6 +143,23 @@ describe('LabelFilters', () => {
     setup({ labelsFilters: [], labelFilterRequired: true });
     expect(screen.getByText(MISSING_LABEL_FILTER_ERROR_MESSAGE)).toBeInTheDocument();
   });
+
+  it('renders accessible labels for label filter operators', async () => {
+    setup({
+      labelsFilters: [{ label: 'foo', op: '=~', value: 'bar' }],
+    });
+
+    const operatorSelect = screen.getByRole('combobox', { name: 'Label filter operator' });
+    expect(operatorSelect).toBeInTheDocument();
+    expect(screen.getByText('=~')).toBeInTheDocument();
+
+    await userEvent.click(operatorSelect);
+
+    expect(screen.getByRole('option', { name: '=' })).toHaveAttribute('title', 'Equals');
+    expect(screen.getByRole('option', { name: '!=' })).toHaveAttribute('title', 'Not equals');
+    expect(screen.getByRole('option', { name: '=~' })).toHaveAttribute('title', 'Regex match');
+    expect(screen.getByRole('option', { name: '!~' })).toHaveAttribute('title', 'Not regex match');
+  });
 });
 
 function setup(propOverrides?: Partial<ComponentProps<typeof LabelFilters>>) {


### PR DESCRIPTION
## Summary

This PR adds descriptive hover titles to the Prometheus label filter operators:

- `=` -> `Equals`
- `!=` -> `Not equals`
- `=~` -> `Regex match`
- `!~` -> `Not regex match`

## Why

The operator dropdown currently shows symbolic operators only.

This change adds hover titles so users can quickly understand the meaning of each operator without changing the visible dropdown layout.

## Notes

- Keeps the visual UI compact
- Avoids the layout issues caused by inline descriptions in the dropdown
<img width="400" height="235" alt="image" src="https://github.com/user-attachments/assets/e773c719-ce8b-4b0e-b1af-1fb798eb3896" />

Refs grafana/grafana#67028
