### PR TITLE
Add support for decoding compressed responses

### DIFF
--- a/.changeset/funny-carpets-add.md
+++ b/.changeset/funny-carpets-add.md
@@ -1,0 +1,5 @@
+---
+'promlib': minor
+---
+
+Add support for decoding compressed response bodies

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/grafana-prometheus-datasource/pkg/promlib
 go 1.26.3
 
 require (
+	github.com/andybalholm/brotli v1.2.0
 	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3
 	github.com/grafana/grafana-plugin-sdk-go v0.292.0
 	github.com/grafana/grafana/apps/scope v0.0.0-20260427171703-d4f46decefcb

--- a/pkg/promlib/go.sum
+++ b/pkg/promlib/go.sum
@@ -319,6 +319,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -68,10 +67,7 @@ func (r *Resource) Execute(ctx context.Context, req *backend.CallResourceRequest
 		}
 	}()
 
-	var buf bytes.Buffer
-	// Should be more efficient than ReadAll. See https://github.com/prometheus/client_golang/pull/976
-	_, err = buf.ReadFrom(resp.Body)
-	body := buf.Bytes()
+	body, err := utils.Decode(resp.Header.Get("Content-Encoding"), resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promlib/resource/resource_test.go
+++ b/pkg/promlib/resource/resource_test.go
@@ -2,6 +2,7 @@ package resource_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	scope "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
+	schemas "github.com/grafana/schemads"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -80,6 +82,33 @@ func TestResource_Execute(t *testing.T) {
 	resp, err := res.Execute(ctx, req)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestResource_ExecuteDecodesCompressedResponse(t *testing.T) {
+	body := []byte(`{"message":"success"}`)
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{
+			Response: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(gzipBody(t, body))),
+				Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+			},
+		},
+	}
+	settings := backend.DataSourceInstanceSettings{
+		ID:       1,
+		URL:      "http://mock-server",
+		JSONData: []byte(`{}`),
+	}
+	res, err := resource.New(mockClient, settings, log.DefaultLogger)
+	require.NoError(t, err)
+
+	resp, err := res.Execute(context.Background(), &backend.CallResourceRequest{
+		URL: "/test",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, body, resp.Body)
 }
 
 func TestResource_GetSuggestions(t *testing.T) {
@@ -186,4 +215,58 @@ func TestResource_GetSuggestionsWithEmptyQueriesButFilters(t *testing.T) {
 	// Check that both label matchers are present with their correct values
 	assert.Contains(t, decodedMatch, `job="testjob"`)
 	assert.Contains(t, decodedMatch, `instance="localhost:9090"`)
+}
+
+func TestSchemaProvider_ColumnsDecodesCompressedResponses(t *testing.T) {
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{
+			customRoundTrip: func(req *http.Request) (*http.Response, error) {
+				var body []byte
+				switch req.URL.Path {
+				case "/api/v1/labels":
+					body = []byte(`{"status":"success","data":["job"]}`)
+				case "/api/v1/metadata":
+					body = []byte(`{"status":"success","data":{"up":[{"type":"gauge","help":"Up help","unit":"short"}]}}`)
+				default:
+					t.Fatalf("unexpected request path: %s", req.URL.Path)
+				}
+
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader(gzipBody(t, body))),
+					Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+				}, nil
+			},
+		},
+	}
+	settings := backend.DataSourceInstanceSettings{
+		ID:       1,
+		URL:      "http://localhost:9090",
+		JSONData: []byte(`{"httpMethod": "GET"}`),
+	}
+	res, err := resource.New(mockClient, settings, log.DefaultLogger)
+	require.NoError(t, err)
+
+	provider := resource.NewSchemaProvider(res)
+	resp, err := provider.Columns(context.Background(), &schemas.ColumnsRequest{
+		Tables: []string{"up"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resp.Columns["up"], 3)
+	require.Equal(t, "job", resp.Columns["up"][2].Name)
+	require.Equal(t, "Up help", resp.TableMetadata["up"].Description)
+	require.Equal(t, "short", resp.TableMetadata["up"].Unit)
+}
+
+func gzipBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
 }

--- a/pkg/promlib/resource/schema.go
+++ b/pkg/promlib/resource/schema.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	schemas "github.com/grafana/schemads"
+
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/utils"
 )
 
 // SchemaProvider implements schemads SchemaHandler, TablesHandler, and ColumnsHandler
@@ -165,8 +167,13 @@ func (p *SchemaProvider) fetchPrometheusLabels(ctx context.Context, path string,
 	}
 	defer resp.Body.Close()
 
+	body, err := utils.Decode(resp.Header.Get("Content-Encoding"), resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read labels response (description=%q): %w", description, err)
+	}
+
 	var result prometheusLabelsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("failed to decode labels response (description=%q): %w", description, err)
 	}
 
@@ -211,8 +218,13 @@ func (p *SchemaProvider) fetchMetricMetadata(ctx context.Context, metric string)
 	}
 	defer resp.Body.Close()
 
+	body, err := utils.Decode(resp.Header.Get("Content-Encoding"), resp.Body)
+	if err != nil {
+		return schemas.Metadata{}, fmt.Errorf("failed to read metadata response (metric=%q): %w", metric, err)
+	}
+
 	var result prometheusMetadataResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return schemas.Metadata{}, fmt.Errorf("failed to decode metadata response (metric=%q): %w", metric, err)
 	}
 	if result.Status != "success" {
@@ -244,8 +256,8 @@ func (p *SchemaProvider) fetchMetricTables(ctx context.Context) ([]schemas.Table
 	tables := make([]schemas.Table, len(names))
 	for i, name := range names {
 		tables[i] = schemas.Table{
-			Name:    name,
-			Columns: baseColumns,
+			Name:       name,
+			Columns:    baseColumns,
 			TableHints: prometheusTableHints,
 		}
 	}

--- a/pkg/promlib/utils/utils.go
+++ b/pkg/promlib/utils/utils.go
@@ -1,10 +1,15 @@
 package utils
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
+	"github.com/andybalholm/brotli"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -30,4 +35,44 @@ func StartTrace(ctx context.Context, tracer trace.Tracer, name string, attribute
 	return ctx, func() {
 		span.End()
 	}
+}
+
+// Adapted from grafana/grafana-azuremonitor-datasource
+// This function handles various compression mechanisms that may have been used on a response body
+// Determine encoding by: encoding := resp.Header.Get("Content-Encoding")
+func Decode(encoding string, original io.ReadCloser) ([]byte, error) {
+	var reader io.Reader
+	var err error
+	switch encoding {
+	case "gzip":
+		reader, err = gzip.NewReader(original)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := reader.(io.ReadCloser).Close(); err != nil {
+				backend.Logger.Warn("Failed to close reader body", "err", err)
+			}
+		}()
+	case "deflate":
+		reader = flate.NewReader(original)
+		defer func() {
+			if err := reader.(io.ReadCloser).Close(); err != nil {
+				backend.Logger.Warn("Failed to close reader body", "err", err)
+			}
+		}()
+	case "br":
+		reader = brotli.NewReader(original)
+	case "":
+		reader = original
+	default:
+		return nil, fmt.Errorf("unexpected encoding type %q", encoding)
+	}
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(reader)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/pkg/promlib/utils/utils_test.go
+++ b/pkg/promlib/utils/utils_test.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	body := []byte("prometheus response")
+
+	tests := []struct {
+		name     string
+		encoding string
+		body     []byte
+	}{
+		{
+			name:     "no compression",
+			encoding: "",
+			body:     body,
+		},
+		{
+			name:     "gzip",
+			encoding: "gzip",
+			body:     gzipBody(t, body),
+		},
+		{
+			name:     "deflate",
+			encoding: "deflate",
+			body:     deflateBody(t, body),
+		},
+		{
+			name:     "brotli",
+			encoding: "br",
+			body:     brotliBody(t, body),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded, err := Decode(tc.encoding, io.NopCloser(bytes.NewReader(tc.body)))
+
+			require.NoError(t, err)
+			require.Equal(t, body, decoded)
+		})
+	}
+}
+
+func TestDecodeReturnsErrorForInvalidGzip(t *testing.T) {
+	_, err := Decode("gzip", io.NopCloser(bytes.NewReader([]byte("not gzip"))))
+
+	require.Error(t, err)
+}
+
+func TestDecodeReturnsErrorUnknownEncoding(t *testing.T) {
+	_, err := Decode("zstd", io.NopCloser(bytes.NewReader([]byte("body"))))
+
+	require.EqualError(t, err, `unexpected encoding type "zstd"`)
+}
+
+func gzipBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+func deflateBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+func brotliBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := brotli.NewWriter(&buf)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
Some responses from Prometheus endpoints are compressed (e.g. using GZip). These responses may not be decompressed and can lead to issues when attempting to parse responses in a client.

This change adds a helper (adapted from the Azure Monitor data source) that will support decompressing various response types.

I've left the query path untouched as I believe that's unaffected.