### PR TITLE
Update golangci-lint-version to 2.11.0

### DIFF
--- a/.changeset/update-golangci-lint-version.md
+++ b/.changeset/update-golangci-lint-version.md
@@ -1,0 +1,5 @@
+---
+'grafana-prometheus-datasource': patch
+---
+
+Update golangci-lint-version to 2.11.0 in push workflow

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,4 +28,4 @@ jobs:
       pull-requests: read
     with:
       go-version: "1.26.3"
-      golangci-lint-version: "2.12.2"
+      golangci-lint-version: "2.11.0"


### PR DESCRIPTION
Downgrade `golangci-lint-version` from `2.12.2` to `2.11.0` in the push workflow.

Made with [Cursor](https://cursor.com)