### PR TITLE
chore: auto-audit hygiene fixes

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,10 +1,9 @@
 # Do not under any circumstances add approvedGitRepositories to this file.
 # It is a security risk that would allow arbitrary code execution both locally and in CI.
 # https://yarnpkg.com/configuration/yarnrc#approvedGitRepositories
+defaultSemverRangePrefix: ""
 
 enableImmutableInstalls: true
-
-defaultSemverRangePrefix: ""
 
 enableScripts: false
 
@@ -14,10 +13,10 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 4320
 
-npmRegistryServer: "https://registry.npmjs.org"
-
-yarnPath: .yarn/releases/yarn-4.15.0.cjs
-
 # Bypass minimal age gate for specific grafana packages to make feature development easier.
 npmPreapprovedPackages:
   - "@grafana/*"
+
+npmRegistryServer: "https://registry.npmjs.org"
+
+yarnPath: .yarn/releases/yarn-4.15.0.cjs

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/react-dom": "18.3.7"
   },
   "engines": {
-    "node": ">=24.5.0"
+    "node": ">=24"
   },
   "dependencies": {
     "@emotion/css": "11.10.6",

--- a/packages/grafana-prometheus-datasource/package.json
+++ b/packages/grafana-prometheus-datasource/package.json
@@ -2,5 +2,8 @@
   "name": "grafana-prometheus-datasource",
   "version": "13.1.1",
   "packageManager": "yarn@4.15.0",
-  "private": true
+  "private": true,
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -124,5 +124,8 @@
     "@grafana/data": "$@grafana/data",
     "@grafana/schema": "$@grafana/schema",
     "@grafana/i18n": "$@grafana/i18n"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/packages/promlib/package.json
+++ b/packages/promlib/package.json
@@ -2,5 +2,8 @@
   "name": "promlib",
   "version": "0.0.12",
   "packageManager": "yarn@4.15.0",
-  "private": true
+  "private": true,
+  "engines": {
+    "node": ">=24"
+  }
 }


### PR DESCRIPTION
Automated repo hygiene audit. This branch applies the following standard changes:

- Set `engines` in `package.json` to `node >=24` (and `npm >=11.15.0` for npm-based repos), across every `package.json` outside `node_modules`.
- Replace `.yarnrc.yml` with the standard template (`enableScripts: false`, `npmMinimalAgeGate: 4320`, etc.).

### Notes

- All commits are SSH-signed.
- Audit was applied uniformly across ~70 Grafana data-source / library repos. See [the audit driver](https://github.com/grafana/) (run locally) for the full ruleset.
- Please skim the diff before merging.