### PR TITLE
fix: update TestQueryTypeDefinitions to match schemabuilder API in sdk v0.292.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # grafana-prometheus-datasource
 
+## Unreleased
+
+🐛 Fix `TestQueryTypeDefinitions` build failure caused by stale schemabuilder API calls
+
 ## 13.1.1
 
 🐛 Enable scheduled task creation in Crowdin workflow

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -506,10 +506,10 @@ func AlignTimeRange(t time.Time, step time.Duration, offset int64) time.Time {
 	return time.Unix(0, int64(math.Floor((float64(t.UnixNano())+offsetNano)/stepNano)*stepNano-offsetNano)).UTC()
 }
 
-//go:embed query.types.json
+//go:embed v0alpha1/query.types.json
 var f embed.FS
 
 // QueryTypeDefinitionListJSON returns the query type definitions
 func QueryTypeDefinitionListJSON() (json.RawMessage, error) {
-	return f.ReadFile("query.types.json")
+	return f.ReadFile("v0alpha1/query.types.json")
 }

--- a/pkg/promlib/models/query_test.go
+++ b/pkg/promlib/models/query_test.go
@@ -1491,8 +1491,8 @@ func TestQueryTypeDefinitions(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	err = builder.AddQueries(
-		schemabuilder.QueryTypeInfo{
+	err = builder.AddQueries([]schemabuilder.QueryTypeInfo{
+		{
 			Name:   "default",
 			GoType: reflect.TypeOf(&models.PrometheusQueryProperties{}),
 			Examples: []sdkapi.QueryExample{
@@ -1506,8 +1506,8 @@ func TestQueryTypeDefinitions(t *testing.T) {
 				},
 			},
 		},
-	)
+	})
 
 	require.NoError(t, err)
-	builder.UpdateQueryDefinition(t, "./")
+	builder.UpdateProviderFiles(t, "v0alpha1", "./")
 }

--- a/pkg/promlib/models/v0alpha1/query.examples.json
+++ b/pkg/promlib/models/v0alpha1/query.examples.json
@@ -1,0 +1,11 @@
+{
+  "examples": [
+    {
+      "name": "simple health check",
+      "queryType": "default",
+      "saveModel": {
+        "expr": "1+1"
+      }
+    }
+  ]
+}

--- a/pkg/promlib/models/v0alpha1/query.types.json
+++ b/pkg/promlib/models/v0alpha1/query.types.json
@@ -153,15 +153,7 @@
             "expr"
           ],
           "type": "object"
-        },
-        "examples": [
-          {
-            "name": "simple health check",
-            "saveModel": {
-              "expr": "1+1"
-            }
-          }
-        ]
+        }
       }
     }
   ]


### PR DESCRIPTION
`TestQueryTypeDefinitions` in `pkg/promlib/models` has been broken since the sdk bump to v0.292.0 — the whole package fails to compile.

Two APIs changed and the test wasn't updated:

- `Builder.AddQueries` now takes `[]QueryTypeInfo` (a slice), the call was passing a bare struct
- `Builder.UpdateQueryDefinition` got removed, replaced by `Builder.UpdateProviderFiles(t, apiVersion, outdir)` which writes to `{outdir}/{apiVersion}/query.types.json`

**Reproduce:**

```
cd pkg/promlib
go test ./models/...
```

You get:

```
models/query_test.go:1495: cannot use schemabuilder.QueryTypeInfo{...} as []schemabuilder.QueryTypeInfo
models/query_test.go:1512: builder.UpdateQueryDefinition undefined
FAIL github.com/.../models [build failed]
```

**Fix:**

- wrap the `QueryTypeInfo` literal in a slice
- swap `UpdateQueryDefinition` for `UpdateProviderFiles(t, "v0alpha1", "./")`
- move `query.types.json` -> `v0alpha1/query.types.json` to match the new output path
- update the `//go:embed` path and `ReadFile` call accordingly
- examples are now in a separate `v0alpha1/query.examples.json` per the new sdk convention

All 11 packages in `pkg/promlib` pass after the fix.