### PR TITLE
Correctly escape label names in the query builder

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/formatter.ts
+++ b/packages/grafana-prometheus/src/querybuilder/components/formatter.ts
@@ -1,5 +1,6 @@
 import { regexifyLabelValuesQueryString } from '../parsingUtils';
 import { type QueryBuilderLabelFilter } from '../shared/types';
+import { utf8Support } from './../../utf8_support';
 
 const formatPrometheusLabelFiltersToString = (
   queryString: string,
@@ -12,7 +13,7 @@ const formatPrometheusLabelFiltersToString = (
 
 export const formatPrometheusLabelFilters = (labelsFilters: QueryBuilderLabelFilter[]): string[] => {
   return labelsFilters.map((label) => {
-    return `,${label.label}="${label.value}"`;
+    return `,${utf8Support(label.label)}="${label.value}"`;
   });
 };
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-prometheus-datasource/issues/178

As a side note, there might be bugs here as well, but I don't know where I could test it in the UI.
https://github.com/grafana/grafana-prometheus-datasource/blob/8fab304d3f4d92b5210eedb5f7ed267259b64f86/packages/grafana-prometheus/src/metric_find_query.ts#L113
https://github.com/grafana/grafana-prometheus-datasource/blob/8fab304d3f4d92b5210eedb5f7ed267259b64f86/packages/grafana-prometheus/src/language_utils.ts#L269
https://github.com/grafana/grafana-prometheus-datasource/blob/8fab304d3f4d92b5210eedb5f7ed267259b64f86/packages/grafana-prometheus/src/result_transformer.ts#L368