### PR TITLE
MetricSelector: Use onCommitChange for series limit input

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -51,7 +51,7 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onCommitChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'


### PR DESCRIPTION
Switch the series limit input from `onChange` to `onCommitChange` so that the series endpoint is only queried when the user blurs the input or presses Enter, instead of making a request on every keystroke.

Fixes #120727