### PR TITLE
Prometheus: preserve non-le labels in heatmap frame names

### DIFF
--- a/.changeset/tall-otters-heal.md
+++ b/.changeset/tall-otters-heal.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Preserve non-`le` labels in heatmap frame names. When a histogram is queried with grouping labels (e.g. `sum by (le, foo) (some_metric_bucket)`) and rendered as a Heatmap, merged frames were named after the lowest `le` bucket value and dropped the other labels, so the legend showed `0.005`, `0.01`, … for every grouping instead of `{foo="bar"}`, `{foo="baz"}`. The merged-frame name is now built from the non-`le` labels so each partition reflects its label set.

--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -975,6 +975,146 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[2].fields[3].values).toEqual([10, 0, 0]);
     });
 
+    it('results with heatmap format and multiple histograms should retain non-le labels in frame names', () => {
+      // Regression test: sum by (le, foo) (some_metric_bucket) should preserve the "foo" label
+      // in each heatmap frame name rather than naming frames by the lowest le bucket value.
+      const options = {
+        targets: [
+          {
+            format: 'heatmap',
+            refId: 'A',
+          },
+        ],
+      } as unknown as DataQueryRequest<PromQuery>;
+      const response = {
+        state: 'Done',
+        data: [
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [10, 10, 0],
+                labels: { le: '1', foo: 'bar' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [20, 10, 30],
+                labels: { le: '2', foo: 'bar' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [0, 10, 10],
+                labels: { le: '1', foo: 'baz' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [20, 10, 40],
+                labels: { le: '2', foo: 'baz' },
+              },
+            ],
+          }),
+        ],
+      } as unknown as DataQueryResponse;
+
+      const series = transformV2(response, options, {});
+      expect(series.data).toHaveLength(2);
+      const names = series.data.map((f) => f.name).sort();
+      expect(names).toEqual(['{foo="bar"}', '{foo="baz"}']);
+    });
+
+    it('results with heatmap format and metric name with multiple histograms should include metric name in frame name', () => {
+      const options = {
+        targets: [
+          {
+            format: 'heatmap',
+            refId: 'A',
+          },
+        ],
+      } as unknown as DataQueryRequest<PromQuery>;
+      const response = {
+        state: 'Done',
+        data: [
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'my_metric',
+                type: FieldType.number,
+                values: [10, 10, 0],
+                labels: { le: '1', foo: 'bar', __name__: 'my_metric' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'my_metric',
+                type: FieldType.number,
+                values: [20, 10, 30],
+                labels: { le: '2', foo: 'bar', __name__: 'my_metric' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'my_metric',
+                type: FieldType.number,
+                values: [0, 10, 10],
+                labels: { le: '1', foo: 'baz', __name__: 'my_metric' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'my_metric',
+                type: FieldType.number,
+                values: [20, 10, 40],
+                labels: { le: '2', foo: 'baz', __name__: 'my_metric' },
+              },
+            ],
+          }),
+        ],
+      } as unknown as DataQueryResponse;
+
+      const series = transformV2(response, options, {});
+      expect(series.data).toHaveLength(2);
+      const names = series.data.map((f) => f.name).sort();
+      expect(names).toEqual(['my_metric{foo="bar"}', 'my_metric{foo="baz"}']);
+    });
+
     it('Retains exemplar frames when data returned is a heatmap', () => {
       const options = {
         targets: [

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -385,9 +385,19 @@ function mergeHeatmapFrames(frames: DataFrame[]): DataFrame[] {
     };
   });
 
+  const firstValueField = frames[0].fields.find((field) => field.type === FieldType.number);
+  const { le, __name__, ...nonLeLabels } = firstValueField?.labels ?? {};
+  const nonLeEntries = Object.entries(nonLeLabels);
+  let frameName: string | undefined = frames[0].name;
+  if (nonLeEntries.length > 0) {
+    const labelStr = nonLeEntries.map(([k, v]) => `${k}="${v}"`).join(', ');
+    frameName = __name__ ? `${__name__}{${labelStr}}` : `{${labelStr}}`;
+  }
+
   return [
     {
       ...frames[0],
+      name: frameName,
       meta: {
         ...frames[0].meta,
         type: DataFrameType.HeatmapRows,


### PR DESCRIPTION
When a histogram is queried with `sum by (le, foo) (some_metric_bucket)` and the panel format is set to Heatmap, the merged frames were named after the lowest `le` bucket value, discarding extra labels like `foo` entirely — so the legend showed `0.005`, `0.01`, etc. for every grouping instead of `{foo="bar"}`, `{foo="baz"}`. This change builds the merged-frame name in `mergeHeatmapFrames` from the non-`le` labels (skipping `__name__` and `le`) so each partition reflects its label set, falling back to the existing `frames[0].name` when there are no non-`le` labels. Two regression tests cover the plain-label and metric-name cases.

This was originally submitted against `grafana/grafana` ([grafana/grafana#121601](https://github.com/grafana/grafana/pull/121601)) before the Prometheus datasource was extracted into this repository with moving the fix here since the original target files no longer exist in `grafana/grafana`.