### PR TITLE
docs: clarify changeset-based release steps for publishing @grafana/prometheus

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,9 @@ The workflow will build the library and print a summary of what _would_ be publi
 
    > **Note:** Changesets are added in feature PRs via `yarn changeset`. Make sure every feature PR that should appear in the release includes one — without pending changesets there is nothing to version.
 
-3. **Bump the version** in `packages/grafana-prometheus/package.json` and merge to `main`.
+   > **Note:** If a PR intentionally needs no changelog entry, add the `no-changelog` label to it so the changeset CI check passes.
+
+3. **Verify the bumped version** in `packages/grafana-prometheus/package.json` — no manual bump is needed when `changeset:version` succeeds.
    The npm dist-tag is derived automatically from the version string:
 
    | Version        | npm tag  |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,7 +68,13 @@ The workflow will build the library and print a summary of what _would_ be publi
 
 ### Publishing a release
 
-1. **Bump the version** in `packages/grafana-prometheus/package.json` and merge to `main`.
+1. **Create a release branch** from `main`, named like `release-grafana-prometheus-<version>`, and open a PR.
+
+2. **Apply pending changesets** on that branch by running `yarn changeset:version` and selecting `@grafana/prometheus` (or pass `--library`). This consumes the pending changesets, bumps the version in `packages/grafana-prometheus/package.json`, and updates its `CHANGELOG.md`.
+
+   > **Note:** Changesets are added in feature PRs via `yarn changeset`. Make sure every feature PR that should appear in the release includes one — without pending changesets there is nothing to version.
+
+3. **Bump the version** in `packages/grafana-prometheus/package.json` and merge to `main`.
    The npm dist-tag is derived automatically from the version string:
 
    | Version        | npm tag  |
@@ -77,8 +83,9 @@ The workflow will build the library and print a summary of what _would_ be publi
    | `1.2.0-dev.1`  | `dev`    |
    | `1.0.0-beta.3` | `beta`   |
 
-2. Go to the repo on GitHub → **Actions** → **Publish @grafana/prometheus to NPM**.
-3. Click **Run workflow** → select `main` → leave **Dry run** unchecked → **Run workflow**.
+4. **Merge the release PR** to `main`.
+
+5. **Run the publish workflow**: go to the repo on GitHub → **Actions** → **Publish @grafana/prometheus to NPM** → **Run workflow** → select `main` → leave **Dry run** unchecked → **Run workflow**.
 
 The workflow will fail with a clear error if the local version is not newer than what's already on npm.
 


### PR DESCRIPTION
## Summary

- Rewrites the "Publishing a release" section in `DEVELOPMENT.md` as a clear 5-step flow: create a `release-grafana-prometheus-<version>` branch/PR → run `yarn changeset:version` to apply pending changesets → bump/verify the version and dist-tag → merge the release PR → run the publish workflow.
- Adds a note that changesets must be added in feature PRs via `yarn changeset` so they appear in the release.

## Checks

- `yarn prettier --check DEVELOPMENT.md` passes (docs-only change).