### PR TITLE
Chore: Fix jest config so package tests are discovered

### DIFF
--- a/.changeset/major-clocks-taste.md
+++ b/.changeset/major-clocks-taste.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Fix running frontend unit tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -51,7 +51,20 @@ const pluginProject = {
   transformIgnorePatterns: [nodeModulesToTransform([...grafanaESModules, 'monaco-promql'])],
 };
 
-// Project 2: the repo-management scripts (node env, no DOM setup).
+// Project 2: the @grafana/prometheus library source under packages/grafana-prometheus.
+// Reuses the plugin project's swc + jsdom + module mappers; only the discovered paths differ.
+// Without this, the package's own unit tests are never run from the repo root. The package's
+// own jest.config.js reuses this project (looked up by displayName) to avoid config drift.
+const libraryProject = {
+  ...pluginProject,
+  displayName: 'library',
+  testMatch: [
+    '<rootDir>/packages/grafana-prometheus/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/packages/grafana-prometheus/src/**/*.{spec,test,jest}.{js,jsx,ts,tsx}',
+  ],
+};
+
+// Project 3: the repo-management scripts (node env, no DOM setup).
 const scriptsProject = {
   displayName: 'scripts',
   rootDir: __dirname,
@@ -61,5 +74,5 @@ const scriptsProject = {
 };
 
 module.exports = {
-  projects: [pluginProject, scriptsProject],
+  projects: [pluginProject, libraryProject, scriptsProject],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
-    "test:ci": "jest --passWithNoTests --maxWorkers 4 && yarn workspace @grafana/prometheus test:ci",
+    "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc -p ./packages/grafana-prometheus/tsconfig.build.json && tsc --noEmit && yarn workspace @grafana/prometheus typecheck",
     "lint": "eslint --cache . && yarn workspace @grafana/prometheus lint",
     "lint:fix": "eslint --cache --fix . && prettier --write --list-different . && yarn workspace @grafana/prometheus lint:fix",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
-    "test:ci": "jest --passWithNoTests --maxWorkers 4",
+    "test:ci": "jest --passWithNoTests --maxWorkers=50%",
     "typecheck": "tsc -p ./packages/grafana-prometheus/tsconfig.build.json && tsc --noEmit && yarn workspace @grafana/prometheus typecheck",
     "lint": "eslint --cache . && yarn workspace @grafana/prometheus lint",
     "lint:fix": "eslint --cache --fix . && prettier --write --list-different . && yarn workspace @grafana/prometheus lint:fix",

--- a/packages/grafana-prometheus/jest.config.js
+++ b/packages/grafana-prometheus/jest.config.js
@@ -1,10 +1,15 @@
-const sharedConfig = require('../../jest.config.js');
-module.exports = {
-  ...sharedConfig,
-  rootDir: '../../',
-  modulePaths: ['<rootDir>/packages/grafana-prometheus/src'],
-  testMatch: [
-    '<rootDir>/packages/grafana-prometheus/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/packages/grafana-prometheus/src/**/*.{spec,test,jest}.{js,jsx,ts,tsx}',
-  ],
-};
+// Reuse the `library` project defined at the repo root so this package's tests run with
+// the same swc + jsdom + module mappers as the rest of the monorepo. We deliberately do NOT
+// spread the root config's default export: it exports a `projects` array, and Jest gives
+// `projects` precedence over any sibling `testMatch`, which previously caused this package's
+// tests to be silently skipped. Selecting a single project (no `projects` key) keeps the
+// project's own `testMatch` in effect.
+const { projects } = require('../../jest.config.js');
+
+const libraryProject = projects.find((project) => project.displayName === 'library');
+
+if (!libraryProject) {
+  throw new Error("Could not find the 'library' Jest project in the root jest.config.js");
+}
+
+module.exports = libraryProject;


### PR DESCRIPTION
## Summary

The `@grafana/prometheus` library unit tests were never actually runnin, neither in CI nor locally. This restores discovery so all ~920 library tests run alongside the plugin tests.

- Add a dedicated `library` Jest project to the root config covering `packages/grafana-prometheus/src`
- Simplify the root `test:ci`
- Rewrite the package config to reuse the `library` project as a single project 