### PR TITLE
Chore: Cover data_provider query/escape/metadata paths with unit tests

### DIFF
--- a/.changeset/data-provider-test-coverage.md
+++ b/.changeset/data-provider-test-coverage.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add unit coverage for the Monaco completion DataProvider (queryMetricNames regex/escape/error handling, metricNamesToMetrics, getHistory). Test-only, no user-facing change.

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
@@ -1,4 +1,8 @@
+import { type HistoryItem, type TimeRange } from '@grafana/data';
+
+import { DEFAULT_COMPLETION_LIMIT, METRIC_LABEL } from '../../../constants';
 import type { PrometheusLanguageProvider } from '../../../language_provider';
+import { type PromQuery } from '../../../types';
 
 import { DataProvider, type DataProviderParams } from './data_provider';
 
@@ -10,9 +14,16 @@ const createLanguageProviderMock = (existingMetadata: Record<string, unknown> = 
   retrieveMetricsMetadata: jest.fn().mockReturnValue(existingMetadata),
 });
 
-const createDataProvider = (languageProvider: Partial<PrometheusLanguageProvider>) => {
-  return new DataProvider({ languageProvider } as DataProviderParams);
+const createDataProvider = (
+  languageProvider: Partial<PrometheusLanguageProvider>,
+  historyProvider: Array<HistoryItem<PromQuery>> = []
+) => {
+  return new DataProvider({ languageProvider, historyProvider } as DataProviderParams);
 };
+
+// queryMetricNames forwards a TimeRange to the language provider untouched; its concrete
+// shape is irrelevant to the logic under test, so a sentinel cast keeps the tests focused.
+const timeRange = { from: 'now-1h', to: 'now' } as unknown as TimeRange;
 
 describe('DataProvider', () => {
   describe('metadata fetching', () => {
@@ -28,6 +39,118 @@ describe('DataProvider', () => {
       });
       createDataProvider(languageProvider);
       expect(languageProvider.queryMetricsMetadata).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('queryMetricNames', () => {
+    it('queries without a matcher when no search term is provided', async () => {
+      const languageProvider = createLanguageProviderMock();
+      languageProvider.queryLabelValues.mockResolvedValue(['up', 'go_goroutines']);
+      const dataProvider = createDataProvider(languageProvider);
+
+      const result = await dataProvider.queryMetricNames(timeRange, undefined);
+
+      expect(result).toEqual(['up', 'go_goroutines']);
+      expect(languageProvider.queryLabelValues).toHaveBeenCalledWith(
+        timeRange,
+        METRIC_LABEL,
+        undefined,
+        DEFAULT_COMPLETION_LIMIT
+      );
+    });
+
+    it('builds a fuzzy __name__ regex matcher from a legacy search term', async () => {
+      const languageProvider = createLanguageProviderMock();
+      languageProvider.queryLabelValues.mockResolvedValue([]);
+      const dataProvider = createDataProvider(languageProvider);
+
+      await dataProvider.queryMetricNames(timeRange, 'requests');
+
+      expect(languageProvider.queryLabelValues).toHaveBeenCalledWith(
+        timeRange,
+        METRIC_LABEL,
+        '{__name__=~".*requests.*"}',
+        DEFAULT_COMPLETION_LIMIT
+      );
+    });
+
+    it('strips wrapping quotes and UTF-8 escapes the search term', async () => {
+      const languageProvider = createLanguageProviderMock();
+      languageProvider.queryLabelValues.mockResolvedValue([]);
+      const dataProvider = createDataProvider(languageProvider);
+
+      await dataProvider.queryMetricNames(timeRange, '"metric.name"');
+
+      // removeQuotesIfExist drops the quotes, then escapeForUtf8Support turns the
+      // non-legacy "." into its escaped code-point form (_2e_).
+      expect(languageProvider.queryLabelValues).toHaveBeenCalledWith(
+        timeRange,
+        METRIC_LABEL,
+        '{__name__=~".*U__metric_2e_name.*"}',
+        DEFAULT_COMPLETION_LIMIT
+      );
+    });
+
+    it('returns an empty array when the language provider rejects', async () => {
+      const languageProvider = createLanguageProviderMock();
+      languageProvider.queryLabelValues.mockRejectedValue(new Error('network down'));
+      const dataProvider = createDataProvider(languageProvider);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await dataProvider.queryMetricNames(timeRange, 'up');
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('returns an empty array when the result is not an array', async () => {
+      const languageProvider = createLanguageProviderMock();
+      languageProvider.queryLabelValues.mockResolvedValue(undefined);
+      const dataProvider = createDataProvider(languageProvider);
+
+      const result = await dataProvider.queryMetricNames(timeRange, undefined);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('metricNamesToMetrics', () => {
+    it('maps metadata help/type with empty-string fallbacks', () => {
+      const languageProvider = createLanguageProviderMock({
+        http_requests_total: { type: 'counter', help: 'Total HTTP requests' },
+      });
+      const dataProvider = createDataProvider(languageProvider);
+
+      const metrics = dataProvider.metricNamesToMetrics(['http_requests_total', 'unknown_metric']);
+
+      expect(metrics).toEqual([
+        { name: 'http_requests_total', help: 'Total HTTP requests', type: 'counter', isUtf8: false },
+        { name: 'unknown_metric', help: '', type: '', isUtf8: false },
+      ]);
+    });
+
+    it('flags non-legacy names as UTF-8', () => {
+      const languageProvider = createLanguageProviderMock({});
+      const dataProvider = createDataProvider(languageProvider);
+
+      const metrics = dataProvider.metricNamesToMetrics(['metric.with.dots']);
+
+      expect(metrics).toEqual([{ name: 'metric.with.dots', help: '', type: '', isUtf8: true }]);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('returns expressions and drops falsy entries', () => {
+      const languageProvider = createLanguageProviderMock();
+      const history: Array<HistoryItem<PromQuery>> = [
+        { ts: 1, query: { refId: 'A', expr: 'up' } },
+        { ts: 2, query: { refId: 'B', expr: '' } },
+        { ts: 3, query: { refId: 'C', expr: 'rate(http_requests_total[5m])' } },
+      ];
+      const dataProvider = createDataProvider(languageProvider, history);
+
+      expect(dataProvider.getHistory()).toEqual(['up', 'rate(http_requests_total[5m])']);
     });
   });
 });


### PR DESCRIPTION
Adds unit tests for `data_provider.ts`: `queryMetricNames` (regex build, UTF-8 escape + quote-strip, `DEFAULT_COMPLETION_LIMIT`, error/non-array -> []), `metricNamesToMetrics` (metadata fallback + `isUtf8`), and `getHistory` (`.filter(Boolean)`).