### PR TITLE
Chore: NeverCaseError message + style nits

### DIFF
--- a/.changeset/monaco-style-nits.md
+++ b/.changeset/monaco-style-nits.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Monaco completion provider: include the offending value in NeverCaseError and replace magic numbers with named constants (internal cleanup, no user-facing change).

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -17,6 +17,10 @@ import { getCompletionProvider, getSuggestOptions } from './monaco-completion-pr
 import { placeHolderScopedVars, validateQuery } from './monaco-completion-provider/validation';
 import { language, languageConfiguration } from './promql';
 
+// How long (ms) the manual-trigger flag stays set after a Ctrl/Cmd+Space, so the
+// completion provider can distinguish an explicit request from typing-driven triggers.
+const MANUAL_TRIGGER_RESET_MS = 300;
+
 const options: monacoTypes.editor.IStandaloneEditorConstructionOptions = {
   codeLens: false,
   contextmenu: false,
@@ -200,7 +204,7 @@ const MonacoQueryField = (props: Props) => {
                 editor.trigger('keyboard', 'editor.action.triggerSuggest', {});
                 setTimeout(() => {
                   completionState.isManualTriggerRequested = false;
-                }, 300);
+                }, MANUAL_TRIGGER_RESET_MS);
               }
             }
           };

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -44,6 +44,9 @@ const metricNamesSearch = {
 // labelName will be shown as selected. So user would know what to type next
 const snippetMarker = '${1:}';
 
+// Maximum number of recent queries surfaced as history completions.
+const MAX_HISTORY_COMPLETIONS = 10;
+
 interface MetricFilterOptions {
   metricNames: string[];
   inputText: string;
@@ -132,7 +135,7 @@ function getAllHistoryCompletions(dataProvider: DataProvider): Completion[] {
   // NOTE: the typescript types are wrong. historyItem.query.expr can be undefined
   const allHistory = dataProvider.getHistory();
   // FIXME: find a better history-limit
-  return allHistory.slice(0, 10).map((expr) => ({
+  return allHistory.slice(0, MAX_HISTORY_COMPLETIONS).map((expr) => ({
     type: 'HISTORY',
     label: expr,
     insertText: expr,

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -596,7 +596,7 @@ export function getSituation(text: string, pos: number): Situation | null {
     ids.push(cur.type.id);
   }
 
-  for (let resolver of RESOLVERS) {
+  for (const resolver of RESOLVERS) {
     // i do not use a foreach because i want to stop as soon
     // as i find something
     if (isPathMatch(resolver.path, ids)) {

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/util.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/util.ts
@@ -22,6 +22,6 @@
 
 export class NeverCaseError extends Error {
   constructor(value: never) {
-    super('should never happen');
+    super(`should never happen, got unexpected value: ${JSON.stringify(value)}`);
   }
 }


### PR DESCRIPTION
Message/style-only: `NeverCaseError` now interpolates the offending value; `const resolver` in situation.ts; named constants `MAX_HISTORY_COMPLETIONS` (completions.ts) and `MANUAL_TRIGGER_RESET_MS` (MonacoQueryField.tsx). No behavioral change.