### PR TITLE
Chore: Fix changelog creation

### DIFF
--- a/scripts/__tests__/sync-changelog.test.js
+++ b/scripts/__tests__/sync-changelog.test.js
@@ -84,7 +84,47 @@ describe('sync-changelog', () => {
     expect(readJson(path.join(root, 'package.json')).version).toBe('13.1.0');
   });
 
+  it('removes the stub CHANGELOG.md after mirroring to the workspace root', () => {
+    fs.writeFileSync(path.join(root, STUB_REL, 'CHANGELOG.md'), '# stub\n\n## 13.1.1\n\nentry\n');
+
+    syncChangelog(root);
+
+    expect(fs.existsSync(path.join(root, STUB_REL, 'CHANGELOG.md'))).toBe(false);
+  });
+
+  it('removes the promlib stub CHANGELOG.md after mirroring to pkg/promlib', () => {
+    fs.writeFileSync(path.join(root, PROMLIB_STUB_REL, 'CHANGELOG.md'), '# promlib\n\n## 0.0.11\n\nentry\n');
+
+    syncChangelog(root, 'promlib');
+
+    expect(fs.existsSync(path.join(root, PROMLIB_STUB_REL, 'CHANGELOG.md'))).toBe(false);
+  });
+
   it('throws on an unknown stub target', () => {
     expect(() => syncChangelog(root, 'mystery')).toThrow(/Unknown stub package/);
+  });
+
+  it('preserves existing root changelog history when the stub only has the new version', () => {
+    // Root already has release history from the previous version
+    fs.writeFileSync(
+      path.join(root, 'CHANGELOG.md'),
+      '# grafana-prometheus-datasource\n\n## 13.1.1\n\n🐛 old fix one\n🐛 old fix two\n'
+    );
+    // changeset version generates a stub that contains ONLY the new version entry
+    fs.writeFileSync(
+      path.join(root, STUB_REL, 'CHANGELOG.md'),
+      '# grafana-prometheus-datasource\n\n## 13.1.2\n\n🐛 new fix\n'
+    );
+
+    syncChangelog(root);
+
+    const rootChangelog = fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8');
+    // Both versions must be present
+    expect(rootChangelog).toContain('## 13.1.2');
+    expect(rootChangelog).toContain('🐛 new fix');
+    expect(rootChangelog).toContain('## 13.1.1');
+    expect(rootChangelog).toContain('🐛 old fix one');
+    // New version must appear before old version
+    expect(rootChangelog.indexOf('## 13.1.2')).toBeLessThan(rootChangelog.indexOf('## 13.1.1'));
   });
 });

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -21,7 +21,7 @@ const STUBS = {
     stubDir: path.join('packages', 'grafana-prometheus-datasource'),
     targetDir: '.',
     syncVersion: true,
-    deleteStubChangelog: false,
+    deleteStubChangelog: true,
   },
   [PROMLIB]: {
     stubDir: path.join('packages', 'promlib'),
@@ -32,6 +32,26 @@ const STUBS = {
     deleteStubChangelog: true,
   },
 };
+
+// Merges a stub changelog (new version only) into an existing target changelog
+// (full history). New version sections from the stub are prepended after the
+// title header so history is never lost.
+function mergeChangelogs(stubContent, existingContent) {
+  const stubVersionIdx = stubContent.indexOf('\n## ');
+  if (stubVersionIdx < 0) {
+    return existingContent;
+  }
+  const newVersionBlock = stubContent.slice(stubVersionIdx + 1).trimEnd();
+
+  const existingVersionIdx = existingContent.indexOf('\n## ');
+  if (existingVersionIdx < 0) {
+    return stubContent;
+  }
+  const header = existingContent.slice(0, existingVersionIdx + 1);
+  const existingBlock = existingContent.slice(existingVersionIdx + 1).trimEnd();
+
+  return header + newVersionBlock + '\n\n' + existingBlock + '\n';
+}
 
 function syncChangelog(repoRoot, pkg = DATASOURCE) {
   const cfg = STUBS[pkg];
@@ -47,7 +67,16 @@ function syncChangelog(repoRoot, pkg = DATASOURCE) {
 
   if (fs.existsSync(stubChangelog)) {
     fs.mkdirSync(targetDir, { recursive: true });
-    fs.copyFileSync(stubChangelog, targetChangelog);
+    const stubContent = fs.readFileSync(stubChangelog, 'utf8');
+    if (fs.existsSync(targetChangelog)) {
+      const existing = fs.readFileSync(targetChangelog, 'utf8');
+      fs.writeFileSync(targetChangelog, mergeChangelogs(stubContent, existing));
+    } else {
+      fs.writeFileSync(targetChangelog, stubContent);
+    }
+    if (cfg.deleteStubChangelog) {
+      fs.rmSync(stubChangelog);
+    }
   }
 
   if (cfg.syncVersion) {
@@ -69,4 +98,4 @@ if (require.main === module) {
   syncChangelog(path.join(__dirname, '..'), arg);
 }
 
-module.exports = { syncChangelog, DATASOURCE, PROMLIB, STUBS };
+module.exports = { syncChangelog, mergeChangelogs, DATASOURCE, PROMLIB, STUBS };


### PR DESCRIPTION
When you run `yarn changeset:version` to cut a new version, latest version changelog is overriding the existing one. This PR is fixing it. 