### PR TITLE
Chore: Add blank line in between changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,19 @@
 ## 13.1.1
 
 🐛 Enable scheduled task creation in Crowdin workflow
+
 🐛 Add keywords in plugin.json
+
 🐛 disable yarn scripts
+
 🐛 Add publish-and-deploy job
+
 🐛 Add more rc files to disable running scripts
+
 🐛 Implement i18n support
+
 🐛 Introduce changesets
+
 🐛 Update golangci-lint-version to 2.11.0 in push workflow
+
 🐛 Bump go version to v1.26.3

--- a/pkg/promlib/CHANGELOG.md
+++ b/pkg/promlib/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## 0.0.12
 
 🔐 Dependency version bumps for security
+
 🚀 Add support for decoding compressed responses (#93)
+
 🔐 Chore: Bump go version to v1.26.3 (#92)
+
 🚀 Schemads: Surface per-metric metadata via schemads TableMetadata (#79)
+
 🚀 Add support for decoding compressed response bodies

--- a/scripts/__tests__/version-changeset.test.js
+++ b/scripts/__tests__/version-changeset.test.js
@@ -200,7 +200,7 @@ describe('version-changeset / flattenChangelog', () => {
     return file;
   }
 
-  it('removes Major/Minor/Patch sub-headings and collapses blank lines between entries', () => {
+  it('removes Major/Minor/Patch sub-headings and separates entries with blank lines', () => {
     const file = writeChangelog(
       [
         '# @grafana/prometheus',
@@ -226,7 +226,18 @@ describe('version-changeset / flattenChangelog', () => {
 
     expect(changed).toBe(true);
     expect(fs.readFileSync(file, 'utf8')).toBe(
-      ['# @grafana/prometheus', '', '## 14.0.0', '', '🎉 Breaking change', '🚀 Add util', '🐛 Fix panel', ''].join('\n')
+      [
+        '# @grafana/prometheus',
+        '',
+        '## 14.0.0',
+        '',
+        '🎉 Breaking change',
+        '',
+        '🚀 Add util',
+        '',
+        '🐛 Fix panel',
+        '',
+      ].join('\n')
     );
   });
 
@@ -257,9 +268,56 @@ describe('version-changeset / flattenChangelog', () => {
     flattenChangelog(file);
 
     expect(fs.readFileSync(file, 'utf8')).toBe(
-      ['# @grafana/prometheus', '', '## 14.0.0', '', '🎉 Break', '🐛 Fix A', '', '## 13.2.0', '', '🚀 Util', ''].join(
-        '\n'
-      )
+      [
+        '# @grafana/prometheus',
+        '',
+        '## 14.0.0',
+        '',
+        '🎉 Break',
+        '',
+        '🐛 Fix A',
+        '',
+        '## 13.2.0',
+        '',
+        '🚀 Util',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('separates each entry with a blank line so markdown renders them on separate lines', () => {
+    const file = writeChangelog(
+      [
+        '# grafana-prometheus-datasource',
+        '',
+        '## 13.1.1',
+        '',
+        '### Patch Changes',
+        '',
+        '🐛 Fix A',
+        '',
+        '🐛 Fix B',
+        '',
+        '🐛 Fix C',
+        '',
+      ].join('\n')
+    );
+
+    flattenChangelog(file);
+
+    expect(fs.readFileSync(file, 'utf8')).toBe(
+      [
+        '# grafana-prometheus-datasource',
+        '',
+        '## 13.1.1',
+        '',
+        '🐛 Fix A',
+        '',
+        '🐛 Fix B',
+        '',
+        '🐛 Fix C',
+        '',
+      ].join('\n')
     );
   });
 
@@ -270,7 +328,9 @@ describe('version-changeset / flattenChangelog', () => {
       '## 14.0.0',
       '',
       '🎉 Breaking change',
+      '',
       '🚀 Add util',
+      '',
       '🐛 Fix panel',
       '',
     ].join('\n');

--- a/scripts/version-changeset.js
+++ b/scripts/version-changeset.js
@@ -211,6 +211,7 @@ function flattenChangelog(changelogPath) {
       if (line.trim() === '') {
         continue;
       }
+      pushBlankSeparator();
       out.push(line);
       continue;
     }


### PR DESCRIPTION
Without adding blank line all entries will show up in the same line. 
See current changelog https://github.com/grafana/grafana-prometheus-datasource/blob/cf63ed86d41e17d296fc0a46a1cc5fe6d3d731e0/CHANGELOG.md

See the changelog after this fix https://github.com/grafana/grafana-prometheus-datasource/blob/a71b0cd8ddecfefab8d95e6a08a3e8901c5971db/CHANGELOG.md