### PR TITLE
Chore: Harden release npm workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -19,6 +19,13 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Verify branch is main
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::This workflow can only be run on the main branch. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
       - name: Verify caller is a repo admin
         env:
           GH_TOKEN: ${{ github.token }}
@@ -64,6 +71,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
- release-npm workflow can only be run on `main` branch.
- add `package-manager-cache: false`