### PR TITLE
Add ui options and format options props to PromQueryBuilderOptions

### DIFF
--- a/.changeset/breezy-pens-mix.md
+++ b/.changeset/breezy-pens-mix.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add optional `uiOptions` and `formatOptions` props to PromQueryBuilderOptions. Defaults preserve current behavior, existing callers see no change.

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/monaco-completion-provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/monaco-completion-provider.test.ts
@@ -331,5 +331,4 @@ describe('monaco-completion-provider', () => {
       });
     });
   });
-
 });

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -678,19 +678,11 @@ export const PromSettings = (props: Props) => {
                         });
                       }}
                       onBlur={(e) =>
-                        validateInput(
-                          e.currentTarget.value,
-                          NON_NEGATIVE_INTEGER_REGEX,
-                          warningThresholdError
-                        )
+                        validateInput(e.currentTarget.value, NON_NEGATIVE_INTEGER_REGEX, warningThresholdError)
                       }
                       data-testid="prom-settings-max-samples-processed-warning-threshold"
                     />
-                    {validateInput(
-                      maxSamplesWarningThreshold,
-                      NON_NEGATIVE_INTEGER_REGEX,
-                      warningThresholdError
-                    )}
+                    {validateInput(maxSamplesWarningThreshold, NON_NEGATIVE_INTEGER_REGEX, warningThresholdError)}
                   </>
                 </InlineField>
                 <InlineField
@@ -739,19 +731,11 @@ export const PromSettings = (props: Props) => {
                         });
                       }}
                       onBlur={(e) =>
-                        validateInput(
-                          e.currentTarget.value,
-                          NON_NEGATIVE_INTEGER_REGEX,
-                          errorThresholdError
-                        )
+                        validateInput(e.currentTarget.value, NON_NEGATIVE_INTEGER_REGEX, errorThresholdError)
                       }
                       data-testid="prom-settings-max-samples-processed-error-threshold"
                     />
-                    {validateInput(
-                      maxSamplesErrorThreshold,
-                      NON_NEGATIVE_INTEGER_REGEX,
-                      errorThresholdError
-                    )}
+                    {validateInput(maxSamplesErrorThreshold, NON_NEGATIVE_INTEGER_REGEX, errorThresholdError)}
                   </>
                 </InlineField>
               </>
@@ -820,15 +804,15 @@ export const getValueFromEventItem = (eventItem: SyntheticEvent<HTMLInputElement
 
 const onChangeHandler =
   (key: keyof PromOptions, options: Props['options'], onOptionsChange: Props['onOptionsChange']) =>
-    (eventItem: SyntheticEvent<HTMLInputElement> | SelectableValue<string>) => {
-      onOptionsChange({
-        ...options,
-        jsonData: {
-          ...options.jsonData,
-          [key]: getValueFromEventItem(eventItem),
-        },
-      });
-    };
+  (eventItem: SyntheticEvent<HTMLInputElement> | SelectableValue<string>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        [key]: getValueFromEventItem(eventItem),
+      },
+    });
+  };
 
 function getCustomQueryThresholdParams(customQueryParameters?: string): URLSearchParams {
   if (!customQueryParameters?.trim()) {

--- a/packages/grafana-prometheus/src/constants.ts
+++ b/packages/grafana-prometheus/src/constants.ts
@@ -32,8 +32,7 @@ export const durationError = 'Value is not valid, you can use number with time u
 export const seriesLimitError =
   'Value is not valid, you can use only numbers or leave it empty to use default limit or set 0 to have no limit.';
 
-export const warningThresholdError =
-  'Value is not valid, you can use only non-negative numbers.';
+export const warningThresholdError = 'Value is not valid, you can use only non-negative numbers.';
 
 export const errorThresholdError = 'Value is not valid, you can use only non-negative numbers.';
 

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -45,7 +45,10 @@ export { NestedQueryList } from './querybuilder/components/NestedQueryList';
 export { PromQueryBuilder } from './querybuilder/components/PromQueryBuilder';
 export { PromQueryBuilderContainer } from './querybuilder/components/PromQueryBuilderContainer';
 export { PromQueryBuilderExplained } from './querybuilder/components/PromQueryBuilderExplained';
-export { PromQueryBuilderOptions } from './querybuilder/components/PromQueryBuilderOptions';
+export {
+  PromQueryBuilderOptions,
+  type PromQueryBuilderUIOptions,
+} from './querybuilder/components/PromQueryBuilderOptions';
 export { PromQueryCodeEditor } from './querybuilder/components/PromQueryCodeEditor';
 export { PromQueryEditorSelector } from './querybuilder/components/PromQueryEditorSelector';
 export { PromQueryLegendEditor } from './querybuilder/components/PromQueryLegendEditor';

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -8,7 +8,7 @@ import { CoreApp } from '@grafana/data';
 import { type PromQuery } from '../../types';
 import { getQueryWithDefaults } from '../state';
 
-import { PromQueryBuilderOptions } from './PromQueryBuilderOptions';
+import { PromQueryBuilderOptions, type PromQueryBuilderUIOptions } from './PromQueryBuilderOptions';
 
 describe('PromQueryBuilderOptions', () => {
   it('Can change query type', async () => {
@@ -100,9 +100,55 @@ describe('PromQueryBuilderOptions', () => {
     setup({ exemplar: true });
     expect(screen.getByText('Exemplars: true')).toBeInTheDocument();
   });
+
+  describe('uiOptions', () => {
+    it('hides exemplars switch when uiOptions.exemplars is false', async () => {
+      setup({}, CoreApp.PanelEditor, { exemplars: false });
+      expect(screen.queryByText(/Exemplars:/)).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      expect(screen.queryByLabelText('Exemplars switch.')).not.toBeInTheDocument();
+    });
+
+    it('hides legend section when uiOptions.legend is false', async () => {
+      setup({}, CoreApp.PanelEditor, { legend: false });
+      expect(screen.queryByText(/Legend:/)).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      expect(screen.queryByText('Auto')).not.toBeInTheDocument();
+    });
+
+    it('hides type section when uiOptions.type is false', async () => {
+      setup({}, CoreApp.PanelEditor, { type: false });
+      expect(screen.queryByText(/Type:/)).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      expect(screen.queryByLabelText('Range')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('formatOptions', () => {
+    it('uses the custom format options when provided', async () => {
+      setup({ format: 'table' }, CoreApp.PanelEditor, undefined, [
+        { label: 'Time series', value: 'time_series' },
+        { label: 'Table', value: 'table' },
+      ]);
+
+      expect(screen.getByText('Format: Table')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      await userEvent.click(screen.getByLabelText('Format combobox'));
+      expect(screen.queryByText('Heatmap')).not.toBeInTheDocument();
+    });
+  });
 });
 
-function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.PanelEditor) {
+function setup(
+  queryOverrides: Partial<PromQuery> = {},
+  app: CoreApp = CoreApp.PanelEditor,
+  uiOptions?: PromQueryBuilderUIOptions,
+  formatOptions?: Parameters<typeof PromQueryBuilderOptions>[0]['formatOptions']
+) {
   const props = {
     app,
     query: {
@@ -119,14 +165,8 @@ function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.P
     },
     onRunQuery: jest.fn(),
     onChange: jest.fn(),
-    uiOptions: {
-      exemplars: true,
-      type: true,
-      format: true,
-      minStep: true,
-      legend: true,
-      resolution: true,
-    },
+    uiOptions,
+    formatOptions,
   };
 
   const { container } = render(<PromQueryBuilderOptions {...props} />);

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -16,11 +16,31 @@ import { QueryOptionGroup } from '../shared/QueryOptionGroup';
 
 import { getLegendModeLabel, PromQueryLegendEditor } from './PromQueryLegendEditor';
 
+/**
+ * Per-section visibility flags. Each defaults to `true` when undefined,
+ * so the default rendering is unchanged. Useful for embedders (non-Prometheus
+ * datasources) that only support a subset of these options.
+ *
+ * Note: `exemplars` and `resolution` are also subject to existing conditional
+ * logic — exemplars are still hidden in UnifiedAlerting or when range is off,
+ * and resolution still requires `query.intervalFactor > 1`.
+ */
+export interface PromQueryBuilderUIOptions {
+  legend?: boolean;
+  minStep?: boolean;
+  format?: boolean;
+  type?: boolean;
+  exemplars?: boolean;
+  resolution?: boolean;
+}
+
 interface PromQueryBuilderOptionsProps {
   query: PromQuery;
   app?: CoreApp;
   onChange: (update: PromQuery) => void;
   onRunQuery: () => void;
+  uiOptions?: PromQueryBuilderUIOptions;
+  formatOptions?: Array<SelectableValue<PromQueryFormat>>;
 }
 
 const INTERVAL_FACTOR_OPTIONS: Array<SelectableValue<number>> = map([1, 2, 3, 4, 5, 10], (value: number) => ({
@@ -29,8 +49,15 @@ const INTERVAL_FACTOR_OPTIONS: Array<SelectableValue<number>> = map([1, 2, 3, 4,
 }));
 
 export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
-  ({ query, app, onChange, onRunQuery }) => {
-    const FORMAT_OPTIONS: Array<SelectableValue<PromQueryFormat>> = [
+  ({ query, app, onChange, onRunQuery, uiOptions, formatOptions }) => {
+    const showLegend = uiOptions?.legend ?? true;
+    const showMinStep = uiOptions?.minStep ?? true;
+    const showFormat = uiOptions?.format ?? true;
+    const showType = uiOptions?.type ?? true;
+    const showExemplars = uiOptions?.exemplars ?? true;
+    const showResolution = uiOptions?.resolution ?? true;
+
+    const FORMAT_OPTIONS: Array<SelectableValue<PromQueryFormat>> = formatOptions ?? [
       {
         label: t(
           'grafana-prometheus.querybuilder.prom-query-builder-options.format-options.label-time-series',
@@ -84,72 +111,88 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.options}>
           <QueryOptionGroup
             title={t('grafana-prometheus.querybuilder.prom-query-builder-options.title-options', 'Options')}
-            collapsedInfo={getCollapsedInfo(query, formatOption.label!, queryTypeLabel, app)}
+            collapsedInfo={getCollapsedInfo(query, formatOption.label!, queryTypeLabel, app, {
+              legend: showLegend,
+              minStep: showMinStep,
+              format: showFormat,
+              type: showType,
+              exemplars: showExemplars,
+            })}
           >
-            <PromQueryLegendEditor
-              legendFormat={query.legendFormat}
-              onChange={(legendFormat) => onChange({ ...query, legendFormat })}
-              onRunQuery={onRunQuery}
-            />
-            <EditorField
-              label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-min-step', 'Min step')}
-              tooltip={
-                <>
-                  <Trans
-                    i18nKey="grafana-prometheus.querybuilder.prom-query-builder-options.tooltip-min-step"
-                    values={{
-                      interval: '$__interval',
-                      rateInterval: '$__rate_interval',
-                    }}
-                  >
-                    An additional lower limit for the step parameter of the Prometheus query and for the{' '}
-                    <code>{'{{interval}}'}</code> and <code>{'{{rateInterval}}'}</code> variables.
-                  </Trans>
-                </>
-              }
-            >
-              <AutoSizeInput
-                type="text"
-                aria-label={t(
-                  'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-lower-limit-parameter',
-                  'Min step text box, set lower limit for the step parameter'
-                )}
-                placeholder={t('grafana-prometheus.querybuilder.prom-query-builder-options.placeholder-auto', 'auto')}
-                minWidth={10}
-                onCommitChange={onChangeStep}
-                defaultValue={query.interval}
-                data-testid={selectors.components.DataSource.Prometheus.queryEditor.step}
+            {showLegend && (
+              <PromQueryLegendEditor
+                legendFormat={query.legendFormat}
+                onChange={(legendFormat) => onChange({ ...query, legendFormat })}
+                onRunQuery={onRunQuery}
               />
-            </EditorField>
-            <EditorField label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-format', 'Format')}>
-              <Select
-                data-testid={selectors.components.DataSource.Prometheus.queryEditor.format}
-                value={formatOption}
-                allowCustomValue
-                onChange={onChangeFormat}
-                options={FORMAT_OPTIONS}
-                aria-label={t(
-                  'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-format',
-                  'Format combobox'
-                )}
-              />
-            </EditorField>
-            <EditorField
-              label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-type', 'Type')}
-              data-testid={selectors.components.DataSource.Prometheus.queryEditor.type}
-              useFieldset={false}
-            >
-              <RadioButtonGroup
-                options={queryTypeOptions}
-                value={queryTypeValue}
-                onChange={onQueryTypeChange}
-                aria-label={t(
-                  'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-type',
-                  'Type radio button group'
-                )}
-              />
-            </EditorField>
-            {shouldShowExemplarSwitch(query, app) && (
+            )}
+            {showMinStep && (
+              <EditorField
+                label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-min-step', 'Min step')}
+                tooltip={
+                  <>
+                    <Trans
+                      i18nKey="grafana-prometheus.querybuilder.prom-query-builder-options.tooltip-min-step"
+                      values={{
+                        interval: '$__interval',
+                        rateInterval: '$__rate_interval',
+                      }}
+                    >
+                      An additional lower limit for the step parameter of the Prometheus query and for the{' '}
+                      <code>{'{{interval}}'}</code> and <code>{'{{rateInterval}}'}</code> variables.
+                    </Trans>
+                  </>
+                }
+              >
+                <AutoSizeInput
+                  type="text"
+                  aria-label={t(
+                    'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-lower-limit-parameter',
+                    'Min step text box, set lower limit for the step parameter'
+                  )}
+                  placeholder={t('grafana-prometheus.querybuilder.prom-query-builder-options.placeholder-auto', 'auto')}
+                  minWidth={10}
+                  onCommitChange={onChangeStep}
+                  defaultValue={query.interval}
+                  data-testid={selectors.components.DataSource.Prometheus.queryEditor.step}
+                />
+              </EditorField>
+            )}
+            {showFormat && (
+              <EditorField
+                label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-format', 'Format')}
+              >
+                <Select
+                  data-testid={selectors.components.DataSource.Prometheus.queryEditor.format}
+                  value={formatOption}
+                  allowCustomValue
+                  onChange={onChangeFormat}
+                  options={FORMAT_OPTIONS}
+                  aria-label={t(
+                    'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-format',
+                    'Format combobox'
+                  )}
+                />
+              </EditorField>
+            )}
+            {showType && (
+              <EditorField
+                label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-type', 'Type')}
+                data-testid={selectors.components.DataSource.Prometheus.queryEditor.type}
+                useFieldset={false}
+              >
+                <RadioButtonGroup
+                  options={queryTypeOptions}
+                  value={queryTypeValue}
+                  onChange={onQueryTypeChange}
+                  aria-label={t(
+                    'grafana-prometheus.querybuilder.prom-query-builder-options.aria-label-type',
+                    'Type radio button group'
+                  )}
+                />
+              </EditorField>
+            )}
+            {showExemplars && shouldShowExemplarSwitch(query, app) && (
               <EditorField
                 label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-exemplars', 'Exemplars')}
               >
@@ -164,7 +207,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
                 />
               </EditorField>
             )}
-            {query.intervalFactor && query.intervalFactor > 1 && (
+            {showResolution && query.intervalFactor && query.intervalFactor > 1 && (
               <EditorField
                 label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-resolution', 'Resolution')}
               >
@@ -199,23 +242,39 @@ function getQueryTypeValue(query: PromQuery) {
   return query.range && query.instant ? 'both' : query.instant ? 'instant' : 'range';
 }
 
-function getCollapsedInfo(query: PromQuery, formatOption: string, queryType: string, app?: CoreApp): string[] {
+function getCollapsedInfo(
+  query: PromQuery,
+  formatOption: string,
+  queryType: string,
+  app: CoreApp | undefined,
+  visible: { legend: boolean; minStep: boolean; format: boolean; type: boolean; exemplars: boolean }
+): string[] {
   const items: string[] = [];
 
-  items.push(
-    t('grafana-prometheus.querybuilder.get-collapsed-info.legend', 'Legend: {{value}}', {
-      value: getLegendModeLabel(query.legendFormat),
-    })
-  );
-  items.push(
-    t('grafana-prometheus.querybuilder.get-collapsed-info.format', 'Format: {{value}}', { value: formatOption })
-  );
-  items.push(
-    t('grafana-prometheus.querybuilder.get-collapsed-info.step', 'Step: {{value}}', { value: query.interval ?? 'auto' })
-  );
-  items.push(t('grafana-prometheus.querybuilder.get-collapsed-info.type', 'Type: {{value}}', { value: queryType }));
+  if (visible.legend) {
+    items.push(
+      t('grafana-prometheus.querybuilder.get-collapsed-info.legend', 'Legend: {{value}}', {
+        value: getLegendModeLabel(query.legendFormat),
+      })
+    );
+  }
+  if (visible.format) {
+    items.push(
+      t('grafana-prometheus.querybuilder.get-collapsed-info.format', 'Format: {{value}}', { value: formatOption })
+    );
+  }
+  if (visible.minStep) {
+    items.push(
+      t('grafana-prometheus.querybuilder.get-collapsed-info.step', 'Step: {{value}}', {
+        value: query.interval ?? 'auto',
+      })
+    );
+  }
+  if (visible.type) {
+    items.push(t('grafana-prometheus.querybuilder.get-collapsed-info.type', 'Type: {{value}}', { value: queryType }));
+  }
 
-  if (shouldShowExemplarSwitch(query, app)) {
+  if (visible.exemplars && shouldShowExemplarSwitch(query, app)) {
     items.push(
       t('grafana-prometheus.querybuilder.get-collapsed-info.exemplars', 'Exemplars: {{value}}', {
         value: query.exemplar ? 'true' : 'false',


### PR DESCRIPTION
Adds two optional props to `PromQueryBuilderOptions` so callers can customize the editor to their backend's capabilities.

`uiOptions` is a per-section visibility map (legend, minStep, format, type, exemplars, resolution) that defaults each flag to **true** so current callers see no change.

`formatOptions` lets callers replace the "format" dropdown contents. Existing conditional logic (exemplars hidden in UnifiedAlerting / non-range, resolution gated on `intervalFactor`) is preserved.

The CloudWatch datasource is using `PromQueryBuilderOptions` directly so it stays in sync with the Prometheus UX. CloudWatch's PromQL endpoint doesn't support exemplars and the agent drops histogram metrics on ingestion, so the Exemplars switch and Heatmap format option would expose controls the backend can't handle. This change allows us to hide / customize these options. 