### PR TITLE
Export applyModifyQuery as a standalone helper

### DIFF
--- a/.changeset/icy-parts-beg.md
+++ b/.changeset/icy-parts-beg.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Export applyModifyQuery as a standalone helper so consumers can apply QueryFixActions without instantiating PrometheusDatasource.

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -40,6 +40,7 @@ import {
 } from '@grafana/runtime';
 
 import { addLabelToQuery } from './add_label_to_query';
+import { applyModifyQuery } from './modify_query';
 import { PrometheusAnnotationSupport } from './annotations';
 import { DEFAULT_SERIES_LIMIT, GET_AND_POST_METADATA_ENDPOINTS, InstantQueryRefIdIndex } from './constants';
 import { interpolateQueryExpr, prometheusRegularEscape } from './escaping';
@@ -50,7 +51,7 @@ import {
   PrometheusLanguageProvider,
   type PrometheusLanguageProviderInterface,
 } from './language_provider';
-import { expandRecordingRules, getPrometheusTime, getRangeSnapInterval } from './language_utils';
+import { getPrometheusTime, getRangeSnapInterval } from './language_utils';
 import { PrometheusMetricFindQuery } from './metric_find_query';
 import { getQueryHints } from './query_hints';
 import { renderLabelsWithoutBrackets } from './querybuilder/shared/rendering/labels';
@@ -640,69 +641,7 @@ export class PrometheusDatasource
   }
 
   modifyQuery(query: PromQuery, action: QueryFixAction): PromQuery {
-    let expression = query.expr ?? '';
-    switch (action.type) {
-      case 'ADD_FILTER': {
-        const { key, value } = action.options ?? {};
-        if (key && value) {
-          expression = addLabelToQuery(expression, key, value);
-        }
-
-        break;
-      }
-      case 'ADD_FILTER_OUT': {
-        const { key, value } = action.options ?? {};
-        if (key && value) {
-          expression = addLabelToQuery(expression, key, value, '!=');
-        }
-        break;
-      }
-      case 'ADD_HISTOGRAM_QUANTILE': {
-        expression = `histogram_quantile(0.95, sum(rate(${expression}[$__rate_interval])) by (le))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_AVG': {
-        expression = `histogram_avg(rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_FRACTION': {
-        expression = `histogram_fraction(0,0.2,rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_COUNT': {
-        expression = `histogram_count(rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_SUM': {
-        expression = `histogram_sum(rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_STDDEV': {
-        expression = `histogram_stddev(rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_HISTOGRAM_STDVAR': {
-        expression = `histogram_stdvar(rate(${expression}[$__rate_interval]))`;
-        break;
-      }
-      case 'ADD_RATE': {
-        expression = `rate(${expression}[$__rate_interval])`;
-        break;
-      }
-      case 'ADD_SUM': {
-        expression = `sum(${expression.trim()}) by ($1)`;
-        break;
-      }
-      case 'EXPAND_RULES': {
-        if (action.options) {
-          expression = expandRecordingRules(expression, action.options as any);
-        }
-        break;
-      }
-      default:
-        break;
-    }
-    return { ...query, expr: expression };
+    return applyModifyQuery(query, action);
   }
 
   /**

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -60,6 +60,7 @@ export { MetricsModal } from './querybuilder/components/metrics-modal/MetricsMod
 export { PrometheusDatasource } from './datasource';
 // The parts
 export { addLabelToQuery } from './add_label_to_query';
+export { applyModifyQuery } from './modify_query';
 export { type QueryEditorMode, type PromQueryFormat, type Prometheus } from './dataquery';
 export { interpolateQueryExpr } from './escaping';
 export { loadResources } from './loadResources';

--- a/packages/grafana-prometheus/src/modify_query.test.ts
+++ b/packages/grafana-prometheus/src/modify_query.test.ts
@@ -1,0 +1,66 @@
+import { QueryFixAction } from '@grafana/data';
+
+import { applyModifyQuery } from './modify_query';
+import { PromQuery } from './types';
+
+const baseQuery: PromQuery = { refId: 'A', expr: 'my_metric' };
+
+describe('applyModifyQuery()', () => {
+  it('returns the query unchanged for unknown action types', () => {
+    const action = { type: 'UNKNOWN_ACTION' } as unknown as QueryFixAction;
+    expect(applyModifyQuery(baseQuery, action)).toEqual(baseQuery);
+  });
+
+  it('adds an equality label filter for ADD_FILTER', () => {
+    const action: QueryFixAction = { type: 'ADD_FILTER', options: { key: 'env', value: 'prod' } };
+    expect(applyModifyQuery(baseQuery, action).expr).toBe('my_metric{env="prod"}');
+  });
+
+  it('adds a not-equal label filter for ADD_FILTER_OUT', () => {
+    const action: QueryFixAction = { type: 'ADD_FILTER_OUT', options: { key: 'env', value: 'prod' } };
+    expect(applyModifyQuery(baseQuery, action).expr).toBe('my_metric{env!="prod"}');
+  });
+
+  it('leaves expr untouched when ADD_FILTER is missing key or value', () => {
+    const missingKey: QueryFixAction = { type: 'ADD_FILTER', options: { key: '', value: 'prod' } };
+    const missingValue: QueryFixAction = { type: 'ADD_FILTER', options: { key: 'env', value: '' } };
+    expect(applyModifyQuery(baseQuery, missingKey).expr).toBe('my_metric');
+    expect(applyModifyQuery(baseQuery, missingValue).expr).toBe('my_metric');
+  });
+
+  it('wraps expr in rate() for ADD_RATE', () => {
+    expect(applyModifyQuery(baseQuery, { type: 'ADD_RATE' } as QueryFixAction).expr).toBe(
+      'rate(my_metric[$__rate_interval])'
+    );
+  });
+
+  it('wraps expr in sum() with placeholder for ADD_SUM', () => {
+    expect(applyModifyQuery({ refId: 'A', expr: '  my_metric  ' }, { type: 'ADD_SUM' } as QueryFixAction).expr).toBe(
+      'sum(my_metric) by ($1)'
+    );
+  });
+
+  it.each([
+    ['ADD_HISTOGRAM_QUANTILE', 'histogram_quantile(0.95, sum(rate(my_metric[$__rate_interval])) by (le))'],
+    ['ADD_HISTOGRAM_AVG', 'histogram_avg(rate(my_metric[$__rate_interval]))'],
+    ['ADD_HISTOGRAM_FRACTION', 'histogram_fraction(0,0.2,rate(my_metric[$__rate_interval]))'],
+    ['ADD_HISTOGRAM_COUNT', 'histogram_count(rate(my_metric[$__rate_interval]))'],
+    ['ADD_HISTOGRAM_SUM', 'histogram_sum(rate(my_metric[$__rate_interval]))'],
+    ['ADD_HISTOGRAM_STDDEV', 'histogram_stddev(rate(my_metric[$__rate_interval]))'],
+    ['ADD_HISTOGRAM_STDVAR', 'histogram_stdvar(rate(my_metric[$__rate_interval]))'],
+  ])('wraps expr for histogram action %s', (actionType, expected) => {
+    expect(applyModifyQuery(baseQuery, { type: actionType } as QueryFixAction).expr).toBe(expected);
+  });
+
+  it('preserves non-expr fields on the query', () => {
+    const query: PromQuery = { refId: 'A', expr: 'my_metric', legendFormat: '{{job}}', instant: true };
+    const result = applyModifyQuery(query, { type: 'ADD_RATE' } as QueryFixAction);
+    expect(result.legendFormat).toBe('{{job}}');
+    expect(result.instant).toBe(true);
+  });
+
+  it('treats a missing expr as empty string', () => {
+    const query = { refId: 'A' } as PromQuery;
+    expect(applyModifyQuery(query, { type: 'ADD_RATE' } as QueryFixAction).expr).toBe('rate([$__rate_interval])');
+  });
+});

--- a/packages/grafana-prometheus/src/modify_query.ts
+++ b/packages/grafana-prometheus/src/modify_query.ts
@@ -1,0 +1,71 @@
+import { QueryFixAction } from '@grafana/data';
+
+import { addLabelToQuery } from './add_label_to_query';
+import { expandRecordingRules } from './language_utils';
+import { PromQuery } from './types';
+
+export function applyModifyQuery(query: PromQuery, action: QueryFixAction): PromQuery {
+  let expression = query.expr ?? '';
+  switch (action.type) {
+    case 'ADD_FILTER': {
+      const { key, value } = action.options ?? {};
+      if (key && value) {
+        expression = addLabelToQuery(expression, key, value);
+      }
+      break;
+    }
+    case 'ADD_FILTER_OUT': {
+      const { key, value } = action.options ?? {};
+      if (key && value) {
+        expression = addLabelToQuery(expression, key, value, '!=');
+      }
+      break;
+    }
+    case 'ADD_HISTOGRAM_QUANTILE': {
+      expression = `histogram_quantile(0.95, sum(rate(${expression}[$__rate_interval])) by (le))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_AVG': {
+      expression = `histogram_avg(rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_FRACTION': {
+      expression = `histogram_fraction(0,0.2,rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_COUNT': {
+      expression = `histogram_count(rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_SUM': {
+      expression = `histogram_sum(rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_STDDEV': {
+      expression = `histogram_stddev(rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_HISTOGRAM_STDVAR': {
+      expression = `histogram_stdvar(rate(${expression}[$__rate_interval]))`;
+      break;
+    }
+    case 'ADD_RATE': {
+      expression = `rate(${expression}[$__rate_interval])`;
+      break;
+    }
+    case 'ADD_SUM': {
+      expression = `sum(${expression.trim()}) by ($1)`;
+      break;
+    }
+    case 'EXPAND_RULES': {
+      if (action.options) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expression = expandRecordingRules(expression, action.options as any);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return { ...query, expr: expression };
+}


### PR DESCRIPTION
Exports `applyModifyQuery` so consumers that don't extend `PrometheusDatasource` can apply a `QueryFixAction` (e.g. one produced by `getQueryHints`) without instantiating the PrometheusDatasource class.

Motivation: the CloudWatch datasource is gaining PromQL support and reuses `@grafana/prometheus`'s query field, builder, and hint engine via a minimal `PrometheusDatasource` shim.