### PR TITLE
Prometheus: Fold metric prefix into __name__ adhoc filter

### DIFF
--- a/.changeset/slow-carpets-stick.md
+++ b/.changeset/slow-carpets-stick.md
@@ -1,0 +1,5 @@
+---
+'grafana-prometheus-datasource': patch
+---
+
+Prometheus: Fix "metric name must not be set twice" when an adhoc filter on `__name__` is combined with a query that already sets the metric name as a prefix. The metric prefix is now folded into the `__name__` matcher so the name is specified exactly once. Fixes grafana/grafana#126518.

--- a/.changeset/tangy-towns-grow.md
+++ b/.changeset/tangy-towns-grow.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Prometheus: Fix "metric name must not be set twice" when an adhoc filter on `__name__` is combined with a query that already sets the metric name as a prefix. The metric prefix is now folded into the `__name__` matcher so the name is specified exactly once. Fixes grafana/grafana#126518.

--- a/packages/grafana-prometheus/src/add_label_to_query.test.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.test.ts
@@ -141,4 +141,51 @@ describe('addLabelToQuery()', () => {
       'metric{label="val", "cenk.erdem"="muhabbet"}'
     );
   });
+
+  // Regression tests for https://github.com/grafana/grafana/issues/126518:
+  // Prometheus rejects queries where the metric name is set both as the
+  // selector prefix and as an exact-match `__name__` label
+  // ("metric name must not be set twice"). The metric prefix must be folded
+  // into the `__name__` matcher in that case so the name is specified once.
+  describe('with a __name__ filter', () => {
+    it('should fold the metric prefix into a __name__ matcher (no labels)', () => {
+      expect(addLabelToQuery('metric_name', '__name__', 'metric_name')).toBe('{__name__="metric_name"}');
+    });
+
+    it('should fold the metric prefix into a __name__ matcher while preserving other labels', () => {
+      expect(addLabelToQuery('metric_name{job="x"}', '__name__', 'metric_name')).toBe(
+        '{job="x", __name__="metric_name"}'
+      );
+    });
+
+    it('should let an adhoc __name__ filter override a differing metric prefix', () => {
+      expect(addLabelToQuery('metric_name{job="x"}', '__name__', 'other_metric')).toBe(
+        '{job="x", __name__="other_metric"}'
+      );
+    });
+
+    it('should leave the metric prefix alone for non-equality __name__ operators', () => {
+      expect(addLabelToQuery('metric_name', '__name__', 'metric_name', '=~')).toBe(
+        'metric_name{__name__=~"metric_name"}'
+      );
+      expect(addLabelToQuery('metric_name', '__name__', 'other', '!=')).toBe('metric_name{__name__!="other"}');
+      expect(addLabelToQuery('metric_name', '__name__', 'other', '!~')).toBe('metric_name{__name__!~"other"}');
+    });
+
+    it('should fold the metric prefix in every vector selector of a binary expression', () => {
+      expect(addLabelToQuery('sum(a) / sum(b)', '__name__', 'a')).toBe(
+        'sum({__name__="a"}) / sum({__name__="a"})'
+      );
+    });
+
+    it('should be idempotent when the same __name__ filter is applied twice', () => {
+      expect(addLabelToQuery(addLabelToQuery('metric_name', '__name__', 'metric_name'), '__name__', 'metric_name')).toBe(
+        '{__name__="metric_name"}'
+      );
+    });
+
+    it('should not affect adding non-__name__ adhoc filters to a metric prefix', () => {
+      expect(addLabelToQuery('metric_name', 'job', 'x')).toBe('metric_name{job="x"}');
+    });
+  });
 });

--- a/packages/grafana-prometheus/src/add_label_to_query.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.ts
@@ -62,6 +62,13 @@ function toLabelFilter(key: string, value: string | number, operator: string): Q
   return { label: key, op: operator, value: transformedValue };
 }
 
+// The metric name can be specified in a selector either as the leading
+// identifier (e.g. `metric{...}`) or as a `__name__` matcher inside the
+// braces. Prometheus rejects exact-match duplicates of the name with
+// "metric name must not be set twice", so we must reconcile the two forms
+// when an adhoc/label filter targets `__name__`.
+const NAME_LABEL = '__name__';
+
 function addFilter(
   query: string,
   vectorSelectorPositions: VectorSelectorPosition[],
@@ -78,6 +85,15 @@ function addFilter(
 
     const start = query.substring(prev, match.from);
     const end = isLast ? query.substring(match.to) : '';
+
+    // Fold the metric prefix into the `__name__` matcher when adding an
+    // exact-match `__name__` filter. Without this, rendering would emit
+    // the name twice (as both prefix and label), which Prometheus rejects.
+    // Non-exact operators (`!=`, `=~`, `!~`) can legitimately coexist with
+    // the metric prefix and are left alone.
+    if (filter.label === NAME_LABEL && filter.op === '=' && match.query.metric) {
+      match.query.metric = '';
+    }
 
     const labelToMatch = labelExists(match.query.labels, filter);
     if (labelToMatch) {


### PR DESCRIPTION
## What this PR does

When an ad-hoc filter on `__name__` is added to a query that already names the metric as a selector prefix (e.g. `prometheus_tsdb_head_series{job="prometheus"}`), the resulting query specifies the metric name twice — once as a prefix, once as a `__name__="..."` matcher inside the braces. Prometheus rejects this with:

> 1:1: parse error: metric name must not be set twice: "prometheus_tsdb_head_series" or "prometheus_tsdb_head_series"

This PR teaches `addLabelToQuery` (the function that merges ad-hoc / label filters into a PromQL query) to fold the metric prefix into the `__name__` matcher when the filter is an **exact-match** (`=`) on `__name__`. The metric name is then specified exactly once and Prometheus accepts the query. Non-exact operators (`!=`, `=~`, `!~`) are left untouched because they can legitimately coexist with a metric prefix.

Fixes [grafana/grafana#126518](https://github.com/grafana/grafana/issues/126518).

## Reproduction (before the fix)

1. Dashboard with a Prometheus panel.
2. Query: `prometheus_tsdb_head_series` (metric name set in the code/builder).
3. Add an ad-hoc filter on the dashboard: `__name__ = prometheus_tsdb_head_series`.
4. Panel errors out with `metric name must not be set twice`.

## After the fix

The same scenario renders as `{__name__="prometheus_tsdb_head_series"}` (or `{job="...", __name__="..."}` when other labels are present) and Prometheus returns data normally.

## Where the fix lives

- `packages/grafana-prometheus/src/add_label_to_query.ts` — inside `addFilter`, when the incoming filter is `{ label: "__name__", op: "=" }` and the matched vector selector already has a `metric` prefix in its `PromVisualQuery`, clear the prefix so `renderQuery` emits the name only as a `__name__` matcher.

## Tests

Added a new `describe('with a __name__ filter')` block in `add_label_to_query.test.ts` covering:

- folding the prefix into `__name__` with no other labels
- folding while preserving other labels
- ad-hoc `__name__` overriding a differing metric prefix
- leaving the prefix alone for `=~`, `!=`, `!~`
- folding in every vector selector of a binary expression
- idempotency when the same `__name__` filter is applied twice
- ensuring non-`__name__` ad-hoc filters are unaffected

## Verification

- `yarn workspace @grafana/prometheus jest add_label_to_query` — 26 tests pass (7 new).
- `yarn workspace @grafana/prometheus test:ci` — full library suite 946/946 pass, no regressions.
- `yarn lint` — 0 errors (10 pre-existing warnings, none in changed files).
- `yarn typecheck` — passes.

## Changeset

Included two changeset entries (one for `grafana-prometheus-datasource`, one for `@grafana/prometheus`), both `patch`, since the fix applies to both the plugin and the published library.