### PR TITLE
Chore: Update provisioned datasource configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,22 @@
 services:
+  # Vanilla upstream Prometheus so the provisioned 'prometheus' datasource
+  # (url: http://prometheus:9090) actually points at a running server. It
+  # scrapes itself and the Grafana dev container, giving real metric names,
+  # label names and label values to exercise the plugin against.
+  prometheus:
+    image: prom/prometheus
+    container_name: 'prometheus'
+    volumes:
+      - ./provisioning/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - 9090:9090/tcp
+
   grafana:
     extends:
       file: .config/docker-compose-base.yaml
       service: grafana
+    depends_on:
+      - prometheus
     environment:
       # Grafana 13 enables splashScreen by default; the overlay blocks Playwright interactions.
       GF_FEATURE_TOGGLES_splashScreen: 'false'

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -2,13 +2,13 @@ apiVersion: 1
 
 datasources:
   - name: 'prometheus'
+    uid: 'prometheus'
     type: 'prometheus'
     access: proxy
+    url: 'http://prometheus:9090'
     isDefault: false
     orgId: 1
     version: 1
     editable: true
     jsonData:
-      path: '/resources'
-    secureJsonData:
-      apiKey: 'api-key'
+      httpMethod: 'GET'

--- a/provisioning/prometheus/prometheus.yml
+++ b/provisioning/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+# Scrape config for the dev Prometheus. It scrapes itself and the Grafana dev
+# container so there are real metric names, label names and label values to
+# exercise the plugin against.
+global:
+  scrape_interval: 60s
+  evaluation_interval: 60s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: grafana
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['grafana:3000']


### PR DESCRIPTION
Update provisioned datasource configuration so in devenv grafana-prometheus-datasource would start working out of the box. 
To test it out run the following commands in the repo root.
```
mage -v
yarn build
docker compose up
```

See the default prometheus datasource is up and has metrics