### PR TITLE
Make promql query options reusable by non prometheus datasources

### DIFF
--- a/.changeset/blue-shirts-melt.md
+++ b/.changeset/blue-shirts-melt.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add a `disableTypeBoth` flag to `PromQueryBuilderUIOptions` so embedders can remove the "Both" option from the query Type selector.

--- a/.changeset/ready-beers-lose.md
+++ b/.changeset/ready-beers-lose.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Export resource clients (`LabelsApiClient`, `SeriesApiClient`, `BaseResourceClient`, `ResourceApiClient`)

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -88,6 +88,7 @@ export {
 export { PrometheusVariableSupport } from './variables';
 
 export type { PrometheusLanguageProviderInterface } from './language_provider';
+export { BaseResourceClient, LabelsApiClient, SeriesApiClient, type ResourceApiClient } from './resource_clients';
 
 // For Metrics Drilldown
 export { getPrometheusTime } from './language_utils';

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -125,6 +125,23 @@ describe('PromQueryBuilderOptions', () => {
       await userEvent.click(screen.getByRole('button', { name: /Options/ }));
       expect(screen.queryByLabelText('Range')).not.toBeInTheDocument();
     });
+
+    it('removes the "Both" type option when uiOptions.disableTypeBoth is true', async () => {
+      // PanelEditor would normally offer "Both"
+      setup({}, CoreApp.PanelEditor, { disableTypeBoth: true });
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      expect(screen.getByLabelText('Range')).toBeInTheDocument();
+      expect(screen.getByLabelText('Instant')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Both')).not.toBeInTheDocument();
+    });
+
+    it('keeps the app-based "Both" option when uiOptions.disableTypeBoth is undefined', async () => {
+      setup({}, CoreApp.PanelEditor, {});
+
+      await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+      expect(screen.getByLabelText('Both')).toBeInTheDocument();
+    });
   });
 
   describe('formatOptions', () => {

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -30,6 +30,7 @@ export interface PromQueryBuilderUIOptions {
   minStep?: boolean;
   format?: boolean;
   type?: boolean;
+  disableTypeBoth?: boolean;
   exemplars?: boolean;
   resolution?: boolean;
 }
@@ -86,7 +87,8 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
     };
 
     const queryTypeOptions = getQueryTypeOptions(
-      app === CoreApp.Explore || app === CoreApp.Correlations || app === CoreApp.PanelEditor
+      !uiOptions?.disableTypeBoth &&
+        (app === CoreApp.Explore || app === CoreApp.Correlations || app === CoreApp.PanelEditor)
     );
 
     const onQueryTypeChange = getQueryTypeChangeHandler(query, onChange);


### PR DESCRIPTION
Two small, additions so datasources that use this component library can reuse more of `grafana/prometheus`
- Export the resource clients (`BaseResourceClient`, `LabelsApiClient`,
  `SeriesApiClient`, `ResourceApiClient`). They were
  already exported at the module level but unreachable from the root.
- Add a `disableTypeBoth` flag to `PromQueryBuilderUIOptions` that removes the
  "Both" entry from the query Type selector.

These changes are needed as a part of https://github.com/grafana/grafana/issues/123423
- https://github.com/grafana/grafana-cloudwatch-datasource/pull/568
- https://github.com/grafana/grafana-cloudwatch-datasource/pull/569