### PR TITLE
Chore: Remove publish-and-deploy job

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,15 +17,3 @@ jobs:
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true
-
-  publish-and-deploy:
-    if: github.ref == 'refs/heads/main'
-    uses: grafana/data-sources-ci-workflows/.github/workflows/cd-dev.yml@main
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      pull-requests: read
-    with:
-      go-version: "1.26.4"
-      golangci-lint-version: "2.11.0"


### PR DESCRIPTION
It's creating unnecessary fuzz and in some cases preventing usual release argo workflow to run properly.