### PR TITLE
pkg/promlib: replace schemaless jsonData map with typed PromOptions model

### DIFF
--- a/.changeset/ready-peas-push.md
+++ b/.changeset/ready-peas-push.md
@@ -1,0 +1,5 @@
+---
+'promlib': patch
+---
+
+replace schemaless jsonData map with typed PromOptions model

--- a/pkg/promlib/client/transport.go
+++ b/pkg/promlib/client/transport.go
@@ -3,16 +3,14 @@ package client
 import (
 	"context"
 	"fmt"
-	"strings"
+	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/middleware"
-	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/utils"
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 )
 
 // CreateTransportOptions creates options for the http client.
@@ -22,27 +20,18 @@ func CreateTransportOptions(ctx context.Context, settings backend.DataSourceInst
 		return nil, fmt.Errorf("error getting HTTP options: %w", err)
 	}
 
-	jsonData, err := utils.GetJsonData(settings)
+	jsonData, err := models.ParsePromOptions(settings)
 	if err != nil {
 		return nil, fmt.Errorf("error reading settings: %w", err)
 	}
-	httpMethod, _ := maputil.GetStringOptional(jsonData, "httpMethod")
 
-	opts.Middlewares = middlewares(logger, httpMethod)
-
-	return &opts, nil
-}
-
-func middlewares(logger log.Logger, httpMethod string) []sdkhttpclient.Middleware {
 	middlewares := []sdkhttpclient.Middleware{
-		// TODO: probably isn't needed anymore and should by done by http infra code
 		middleware.CustomQueryParameters(logger),
 	}
-
-	// Needed to control GET vs POST method of the requests
-	if strings.ToLower(httpMethod) == "get" {
+	if jsonData.HTTPMethod == http.MethodGet {
 		middlewares = append(middlewares, middleware.ForceHttpGet(logger))
 	}
+	opts.Middlewares = middlewares
 
-	return middlewares
+	return &opts, nil
 }

--- a/pkg/promlib/models/settings.go
+++ b/pkg/promlib/models/settings.go
@@ -25,10 +25,12 @@ type DataSourceJsonData struct {
 // It mirrors the frontend PromOptions interface (packages/grafana-prometheus/src/types.ts)
 // which extends DataSourceJsonData.
 type PromOptions struct {
-	DataSourceJsonData        // PromOptions extends DataSourceJsonData. Even though it is not directly consumed by the prom datasource, it is consumed via plugin-sdk
-	HTTPMethod         string `json:"httpMethod"`
-	TimeInterval       string `json:"timeInterval"`
-	QueryTimeout       string `json:"queryTimeout"`
+	// PromOptions extends DataSourceJsonData.
+	// Even though it is not directly consumed by the prom datasource, it is consumed via plugin-sdk.
+	DataSourceJsonData
+	HTTPMethod   string `json:"httpMethod"`
+	TimeInterval string `json:"timeInterval"`
+	QueryTimeout string `json:"queryTimeout"`
 
 	// Following fields are parsed for schema completeness but not yet consumed directly
 	// by the backend. They are currently read via opts.CustomOptions["grafanaData"]

--- a/pkg/promlib/models/settings.go
+++ b/pkg/promlib/models/settings.go
@@ -1,0 +1,91 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// DataSourceJsonData mirrors the base @grafana/data DataSourceJsonData interface
+// that all Grafana datasource jsonData types extend.
+type DataSourceJsonData struct {
+	AuthType                    string `json:"authType"`
+	DefaultRegion               string `json:"defaultRegion"`
+	Profile                     string `json:"profile"`
+	ManageAlerts                bool   `json:"manageAlerts"`
+	AllowAsRecordingRulesTarget bool   `json:"allowAsRecordingRulesTarget"`
+	AlertmanagerUID             string `json:"alertmanagerUid"`
+	DisableGrafanaCache         bool   `json:"disableGrafanaCache"`
+}
+
+// PromOptions holds the typed datasource configuration stored in jsonData.
+// It mirrors the frontend PromOptions interface (packages/grafana-prometheus/src/types.ts)
+// which extends DataSourceJsonData.
+type PromOptions struct {
+	DataSourceJsonData        // PromOptions extends DataSourceJsonData. Eventhough it is not directly consumed by the prom datasource, it is consumed via plugin-sdk
+	HTTPMethod         string `json:"httpMethod"`
+	TimeInterval       string `json:"timeInterval"`
+	QueryTimeout       string `json:"queryTimeout"`
+
+	// Following fields are parsed for schema completeness but not yet consumed directly
+	// by the backend. They are currently read via opts.CustomOptions["grafanaData"]
+	// populated by the Grafana SDK. TODO: migrate in a follow-up PR.
+	PrometheusType                      string                       `json:"prometheusType"`
+	PrometheusVersion                   string                       `json:"prometheusVersion"`
+	CustomQueryParameters               string                       `json:"customQueryParameters"`
+	MaxSamplesProcessedWarningThreshold float64                      `json:"maxSamplesProcessedWarningThreshold"`
+	MaxSamplesProcessedErrorThreshold   float64                      `json:"maxSamplesProcessedErrorThreshold"`
+	DisableMetricsLookup                bool                         `json:"disableMetricsLookup"`
+	CacheLevel                          string                       `json:"cacheLevel"`
+	DefaultEditor                       string                       `json:"defaultEditor"`
+	IncrementalQuerying                 bool                         `json:"incrementalQuerying"`
+	IncrementalQueryOverlapWindow       string                       `json:"incrementalQueryOverlapWindow"`
+	DisableRecordingRules               bool                         `json:"disableRecordingRules"`
+	OauthPassThru                       bool                         `json:"oauthPassThru"`
+	SeriesEndpoint                      bool                         `json:"seriesEndpoint"`
+	SeriesLimit                         *int64                       `json:"seriesLimit"`
+	ExemplarTraceIdDestinations         []ExemplarTraceIdDestination `json:"exemplarTraceIdDestinations"`
+}
+
+// ExemplarTraceIdDestination mirrors the frontend ExemplarTraceIdDestination type.
+type ExemplarTraceIdDestination struct {
+	Name            string `json:"name"`
+	URL             string `json:"url,omitempty"`
+	URLDisplayLabel string `json:"urlDisplayLabel,omitempty"`
+	DatasourceUID   string `json:"datasourceUid,omitempty"`
+}
+
+// ParsePromOptions deserialises the datasource jsonData blob into a typed PromOptions
+// struct and validates the fields that are actively used by the backend.
+func ParsePromOptions(settings backend.DataSourceInstanceSettings) (*PromOptions, error) {
+	var opts PromOptions
+	if err := json.Unmarshal(settings.JSONData, &opts); err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSONData: %w", err)
+	}
+	opts.ApplyDefaults()
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return &opts, nil
+}
+
+// ApplyDefaults normalises fields and sets missing values to their defaults.
+func (o *PromOptions) ApplyDefaults() {
+	o.HTTPMethod = strings.ToUpper(strings.TrimSpace(o.HTTPMethod))
+	if o.HTTPMethod == "" {
+		o.HTTPMethod = http.MethodPost
+	}
+}
+
+// Validate checks the fields of PromOptions that are consumed by the backend.
+// Only fields that are actually read during query/resource/transport setup are validated.
+func (o *PromOptions) Validate() error {
+	// HTTPMethod: must be empty (defaults to POST), GET, or POST.
+	if m := strings.ToUpper(o.HTTPMethod); m != "" && m != http.MethodGet && m != http.MethodPost {
+		return fmt.Errorf("invalid httpMethod %q: must be GET or POST", o.HTTPMethod)
+	}
+	return nil
+}

--- a/pkg/promlib/models/settings.go
+++ b/pkg/promlib/models/settings.go
@@ -25,7 +25,7 @@ type DataSourceJsonData struct {
 // It mirrors the frontend PromOptions interface (packages/grafana-prometheus/src/types.ts)
 // which extends DataSourceJsonData.
 type PromOptions struct {
-	DataSourceJsonData        // PromOptions extends DataSourceJsonData. Eventhough it is not directly consumed by the prom datasource, it is consumed via plugin-sdk
+	DataSourceJsonData        // PromOptions extends DataSourceJsonData. Even though it is not directly consumed by the prom datasource, it is consumed via plugin-sdk
 	HTTPMethod         string `json:"httpMethod"`
 	TimeInterval       string `json:"timeInterval"`
 	QueryTimeout       string `json:"queryTimeout"`
@@ -62,7 +62,11 @@ type ExemplarTraceIdDestination struct {
 // struct and validates the fields that are actively used by the backend.
 func ParsePromOptions(settings backend.DataSourceInstanceSettings) (*PromOptions, error) {
 	var opts PromOptions
-	if err := json.Unmarshal(settings.JSONData, &opts); err != nil {
+	data := settings.JSONData
+	if len(data) == 0 {
+		data = []byte("{}")
+	}
+	if err := json.Unmarshal(data, &opts); err != nil {
 		return nil, fmt.Errorf("error unmarshalling JSONData: %w", err)
 	}
 	opts.ApplyDefaults()

--- a/pkg/promlib/models/settings.go
+++ b/pkg/promlib/models/settings.go
@@ -47,11 +47,11 @@ type PromOptions struct {
 	OauthPassThru                       bool                         `json:"oauthPassThru"`
 	SeriesEndpoint                      bool                         `json:"seriesEndpoint"`
 	SeriesLimit                         *int64                       `json:"seriesLimit"`
-	ExemplarTraceIdDestinations         []ExemplarTraceIdDestination `json:"exemplarTraceIdDestinations"`
+	ExemplarTraceIDDestinations         []ExemplarTraceIDDestination `json:"exemplarTraceIdDestinations"`
 }
 
-// ExemplarTraceIdDestination mirrors the frontend ExemplarTraceIdDestination type.
-type ExemplarTraceIdDestination struct {
+// ExemplarTraceIDDestination mirrors the frontend ExemplarTraceIdDestination type.
+type ExemplarTraceIDDestination struct {
 	Name            string `json:"name"`
 	URL             string `json:"url,omitempty"`
 	URLDisplayLabel string `json:"urlDisplayLabel,omitempty"`

--- a/pkg/promlib/models/settings_test.go
+++ b/pkg/promlib/models/settings_test.go
@@ -107,3 +107,95 @@ func TestParsePromOptions_EmptyJSONData(t *testing.T) {
 		})
 	}
 }
+
+func TestPromOptions_ApplyDefaults(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      models.PromOptions
+		wantMethod string
+	}{
+		{
+			name:       "empty HTTPMethod defaults to POST",
+			input:      models.PromOptions{},
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "whitespace-only HTTPMethod defaults to POST",
+			input:      models.PromOptions{HTTPMethod: "   "},
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "lowercase get is normalised to GET",
+			input:      models.PromOptions{HTTPMethod: "get"},
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "mixed-case Post is normalised to POST",
+			input:      models.PromOptions{HTTPMethod: "Post"},
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "whitespace-padded value is trimmed and uppercased",
+			input:      models.PromOptions{HTTPMethod: "  get  "},
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "already-uppercase value is preserved",
+			input:      models.PromOptions{HTTPMethod: http.MethodGet},
+			wantMethod: http.MethodGet,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.input
+			opts.ApplyDefaults()
+			require.Equal(t, tc.wantMethod, opts.HTTPMethod)
+		})
+	}
+}
+
+func TestPromOptions_ApplyDefaults_DoesNotMutateUnrelatedFields(t *testing.T) {
+	seriesLimit := int64(42)
+	opts := models.PromOptions{
+		TimeInterval:   "30s",
+		QueryTimeout:   "60s",
+		PrometheusType: "Prometheus",
+		SeriesLimit:    &seriesLimit,
+	}
+	opts.ApplyDefaults()
+
+	require.Equal(t, "30s", opts.TimeInterval)
+	require.Equal(t, "60s", opts.QueryTimeout)
+	require.Equal(t, "Prometheus", opts.PrometheusType)
+	require.NotNil(t, opts.SeriesLimit)
+	require.Equal(t, int64(42), *opts.SeriesLimit)
+}
+
+func TestPromOptions_Validate(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		wantErrStr string
+	}{
+		{name: "empty is valid", method: ""},
+		{name: "GET is valid", method: http.MethodGet},
+		{name: "POST is valid", method: http.MethodPost},
+		{name: "lowercase get is valid (Validate uppercases before comparing)", method: "get"},
+		{name: "lowercase post is valid", method: "post"},
+		{name: "PUT is rejected", method: http.MethodPut, wantErrStr: `invalid httpMethod "PUT"`},
+		{name: "DELETE is rejected", method: http.MethodDelete, wantErrStr: `invalid httpMethod "DELETE"`},
+		{name: "PATCH is rejected", method: http.MethodPatch, wantErrStr: `invalid httpMethod "PATCH"`},
+		{name: "arbitrary string is rejected", method: "foo", wantErrStr: `invalid httpMethod "foo"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := models.PromOptions{HTTPMethod: tc.method}
+			err := opts.Validate()
+			if tc.wantErrStr != "" {
+				require.ErrorContains(t, err, tc.wantErrStr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/promlib/models/settings_test.go
+++ b/pkg/promlib/models/settings_test.go
@@ -1,0 +1,90 @@
+package models_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
+)
+
+func settingsWithJSON(t *testing.T, v any) backend.DataSourceInstanceSettings {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return backend.DataSourceInstanceSettings{JSONData: b}
+}
+
+func TestParsePromOptions_HTTPMethod(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantMethod string
+		wantErrStr string
+	}{
+		{
+			name:       "empty defaults to POST",
+			input:      "",
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "lowercase get normalised to GET",
+			input:      "get",
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "mixed-case post normalised to POST",
+			input:      "Post",
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "uppercase POST accepted",
+			input:      http.MethodPost,
+			wantMethod: http.MethodPost,
+		},
+		{
+			name:       "uppercase GET accepted",
+			input:      http.MethodGet,
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "whitespace-padded get normalised",
+			input:      "  get  ",
+			wantMethod: http.MethodGet,
+		},
+		{
+			name:       "PUT rejected",
+			input:      "PUT",
+			wantErrStr: `invalid httpMethod "PUT"`,
+		},
+		{
+			name:       "DELETE rejected",
+			input:      "DELETE",
+			wantErrStr: `invalid httpMethod "DELETE"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := models.ParsePromOptions(settingsWithJSON(t, map[string]any{
+				"httpMethod": tc.input,
+			}))
+
+			if tc.wantErrStr != "" {
+				require.ErrorContains(t, err, tc.wantErrStr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMethod, opts.HTTPMethod)
+		})
+	}
+}
+
+func TestParsePromOptions_MalformedJSON(t *testing.T) {
+	settings := backend.DataSourceInstanceSettings{JSONData: []byte(`{not valid json`)}
+	_, err := models.ParsePromOptions(settings)
+	require.ErrorContains(t, err, "error unmarshalling JSONData")
+}

--- a/pkg/promlib/models/settings_test.go
+++ b/pkg/promlib/models/settings_test.go
@@ -88,3 +88,22 @@ func TestParsePromOptions_MalformedJSON(t *testing.T) {
 	_, err := models.ParsePromOptions(settings)
 	require.ErrorContains(t, err, "error unmarshalling JSONData")
 }
+
+func TestParsePromOptions_EmptyJSONData(t *testing.T) {
+	cases := []struct {
+		name     string
+		jsonData []byte
+	}{
+		{name: "nil JSONData", jsonData: nil},
+		{name: "empty slice", jsonData: []byte{}},
+		{name: "empty JSON object", jsonData: []byte(`{}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := backend.DataSourceInstanceSettings{JSONData: tc.jsonData}
+			opts, err := models.ParsePromOptions(settings)
+			require.NoError(t, err)
+			require.Equal(t, http.MethodPost, opts.HTTPMethod)
+		})
+	}
+}

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/status"
 	"go.opentelemetry.io/otel/trace"
 
@@ -22,7 +21,6 @@ import (
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/intervalv2"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/querydata/exemplar"
-	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/utils"
 )
 
 const legendFormatAuto = "__auto"
@@ -55,26 +53,12 @@ func New(
 	plog log.Logger,
 	featureToggles backend.FeatureToggles,
 ) (*QueryData, error) {
-	jsonData, err := utils.GetJsonData(settings)
-	if err != nil {
-		return nil, err
-	}
-	httpMethod, _ := maputil.GetStringOptional(jsonData, "httpMethod")
-	if httpMethod == "" {
-		httpMethod = http.MethodPost
-	}
-
-	timeInterval, err := maputil.GetStringOptional(jsonData, "timeInterval")
+	jsonData, err := models.ParsePromOptions(settings)
 	if err != nil {
 		return nil, err
 	}
 
-	queryTimeout, err := maputil.GetStringOptional(jsonData, "queryTimeout")
-	if err != nil {
-		return nil, err
-	}
-
-	promClient := client.NewClient(httpClient, httpMethod, settings.URL, queryTimeout)
+	promClient := client.NewClient(httpClient, jsonData.HTTPMethod, settings.URL, jsonData.QueryTimeout)
 
 	// standard deviation sampler is the default for backwards compatibility
 	exemplarSampler := exemplar.NewStandardDeviationSampler
@@ -84,7 +68,7 @@ func New(
 		tracer:             tracing.DefaultTracer(),
 		log:                plog,
 		client:             promClient,
-		TimeInterval:       timeInterval,
+		TimeInterval:       jsonData.TimeInterval,
 		ID:                 settings.ID,
 		URL:                settings.URL,
 		exemplarSampler:    exemplarSampler,

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
 	scope "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -30,20 +29,14 @@ func New(
 	settings backend.DataSourceInstanceSettings,
 	plog log.Logger,
 ) (*Resource, error) {
-	jsonData, err := utils.GetJsonData(settings)
+	jsonData, err := models.ParsePromOptions(settings)
 	if err != nil {
 		return nil, err
 	}
-	httpMethod, _ := maputil.GetStringOptional(jsonData, "httpMethod")
-
-	if httpMethod == "" {
-		httpMethod = http.MethodPost
-	}
-
 	return &Resource{
 		log: plog,
 		// we don't use queryTimeout for resource calls
-		promClient: client.NewClient(httpClient, httpMethod, settings.URL, ""),
+		promClient: client.NewClient(httpClient, jsonData.HTTPMethod, settings.URL, ""),
 	}, nil
 }
 

--- a/pkg/promlib/utils/utils.go
+++ b/pkg/promlib/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -14,17 +13,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// GetJsonData just gets the json in easier to work with type. It's used on multiple places which isn't super effective
-// but only when creating a client which should not happen often anyway.
-func GetJsonData(settings backend.DataSourceInstanceSettings) (map[string]any, error) {
-	var jsonData map[string]any
-	err := json.Unmarshal(settings.JSONData, &jsonData)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling JSONData: %w", err)
-	}
-	return jsonData, nil
-}
 
 // StartTrace setups a trace but does not panic if tracer is nil which helps with testing
 func StartTrace(ctx context.Context, tracer trace.Tracer, name string, attributes ...attribute.KeyValue) (context.Context, func()) {


### PR DESCRIPTION
## Summary

**Replace schemaless jsonData parsing with typed PromOptions model**

The backend has been parsing datasource configuration via `utils.GetJsonData` which returns a raw `map[string]any`, then extracting individual fields through `maputil.GetStringOptional`. This is error-prone, untestable, and has no parity with the frontend type definition.

This PR introduces `models.PromOptions` — a typed Go struct that mirrors the frontend `PromOptions` interface in types.ts — and migrates the three call sites that read from `jsonData`.

**Changes**

- `models/settings.go` — new `PromOptions` struct with full field parity to the TS interface, `ParsePromOptions` (unmarshal + defaults + validate), `ApplyDefaults` (normalises `HTTPMethod`), `Validate` (rejects invalid HTTP methods)
- `models/settings_test.go` — table-driven tests covering HTTPMethod normalisation, rejection of invalid methods, and JSON parse errors
- `querydata/request.go`, `resource/resource.go`, `client/transport.go` — migrated from `GetJsonData` + `maputil.GetStringOptional` to `ParsePromOptions`
- `utils/utils.go` — deleted `GetJsonData` (no remaining callers)

**Scope**

Only `HTTPMethod` is validated — this is the only field where the backend's behavior (middleware selection) directly depends on the value being well-formed. `TimeInterval`, `QueryTimeout`, and the remaining fields are parsed into the struct but not validated; the existing call sites handle malformed values at query time, and this PR does not change that behaviour.

Fields in the future-migration block (`customQueryParameters`, thresholds, etc.) are parsed for schema completeness but currently still read by the `CustomQueryParameters` middleware via `opts.CustomOptions["grafanaData"]`. Migrating that path is tracked as a follow-up.

`SeriesLimit` uses `*int64` to correctly represent TypeScript's `number?` — distinguishing "not configured" (`nil`) from explicitly set to zero.

**Follow-ups**
- [ ] Migrate `CustomQueryParameters` middleware to read from `PromOptions` fields directly
- [ ] Parse `PromOptions` once in `newInstanceSettings` and thread it through constructors instead of parsing 3× per instance