### PR TITLE
Fix: fetch metrics on series limit blur instead of change

### DIFF
--- a/.changeset/fix-series-limit-blur.md
+++ b/.changeset/fix-series-limit-blur.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Fix: fetch metrics on series limit blur instead of change

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -15,13 +15,9 @@ export function MetricSelector() {
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
 
-  const [localSeriesLimit, setLocalSeriesLimit] = useState<string | number>(
-    Number.isNaN(seriesLimit) ? '' : seriesLimit
+  const [localSeriesLimit, setLocalSeriesLimit] = useState<string>(
+    Number.isNaN(seriesLimit) ? '' : String(seriesLimit)
   );
-
-  useEffect(() => {
-    setLocalSeriesLimit(Number.isNaN(seriesLimit) ? '' : seriesLimit);
-  }, [seriesLimit]);
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -60,7 +56,10 @@ export function MetricSelector() {
         <div>
           <Input
             onChange={(e) => setLocalSeriesLimit(e.currentTarget.value)}
-            onBlur={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onBlur={(e) => {
+              const parsed = parseInt(e.currentTarget.value.trim(), 10);
+              setSeriesLimit(Number.isNaN(parsed) ? NaN : parsed);
+            }}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -14,6 +14,14 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+
+  const [localSeriesLimit, setLocalSeriesLimit] = useState<string | number>(
+    Number.isNaN(seriesLimit) ? '' : seriesLimit
+  );
+
+  useEffect(() => {
+    setLocalSeriesLimit(Number.isNaN(seriesLimit) ? '' : seriesLimit);
+  }, [seriesLimit]);
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +59,13 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setLocalSeriesLimit(e.currentTarget.value)}
+            onBlur={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={localSeriesLimit}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->

**What this PR does / why we need it**:
This PR changes the `Series limit` input in the Prometheus Metrics Browser to only fetch data `onBlur` instead of `onChange`. Previously, every keystroke in the series limit input caused an immediate fetch request to the backend. By tracking the input locally and only submitting the value on blur, we prevent unnecessary backend queries while the user is still typing.

**Which issue(s) this PR fixes**:
Fixes [#120727](https://github.com/grafana/grafana/issues/120727)

**Special notes for your reviewer**:
- Added `localSeriesLimit` state synced via `useEffect` to capture keystrokes locally `onChange`.
- The context's `setSeriesLimit` (which triggers the debounced fetch) is now only invoked `onBlur`.
- If the input is emptied out, it properly falls back to `NaN` to apply the default limit.
