### PR TITLE
Add forward alert headers middleware

### DIFF
--- a/pkg/promlib/client/transport.go
+++ b/pkg/promlib/client/transport.go
@@ -30,6 +30,13 @@ func CreateTransportOptions(ctx context.Context, settings backend.DataSourceInst
 
 	opts.Middlewares = middlewares(logger, httpMethod)
 
+	// Forward request headers (e.g. the alerting FromAlert / X-Rule-* headers) to
+	// the upstream Prometheus. When the plugin runs as an external (out-of-process)
+	// backend, core Grafana's HTTPClientMiddleware no longer runs in this process,
+	// so the plugin must opt into the SDK's header forwarding itself
+	// Loki did before https://github.com/grafana/grafana/pull/90890
+	opts.ForwardHTTPHeaders = true
+
 	return &opts, nil
 }
 

--- a/pkg/promlib/client/transport_test.go
+++ b/pkg/promlib/client/transport_test.go
@@ -24,4 +24,22 @@ func TestCreateTransportOptions(t *testing.T) {
 		require.Equal(t, http.Header{"Foo": []string{"bar"}}, opts.Header)
 		require.Equal(t, 1, len(opts.Middlewares))
 	})
+
+	// Reproduces the externalization regression: when the plugin runs as an external
+	// (out-of-process) backend, the core Grafana HTTPClientMiddleware that forwards
+	// alerting headers (FromAlert, X-Rule-*) to the upstream is NOT present, because
+	// it lives in the parent Grafana process and does not cross the gRPC boundary.
+	//
+	// The plugin-side equivalent only kicks in when the HTTP client opts in via
+	// ForwardHTTPHeaders. Loki does this (grafana/grafana#90890); Prometheus does not,
+	// which is why flipping Prometheus to external dropped the headers upstream.
+	t.Run("enables ForwardHTTPHeaders so alert headers reach the upstream when externalized", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			URL:      "http://localhost:9090",
+			JSONData: []byte(`{}`),
+		}
+		opts, err := CreateTransportOptions(context.Background(), settings, backend.NewLoggerWith("logger", "test"))
+		require.NoError(t, err)
+		require.True(t, opts.ForwardHTTPHeaders, "ForwardHTTPHeaders must be true so the SDK forwards alert headers to the upstream Prometheus (parity with Loki / grafana#90890)")
+	})
 }

--- a/pkg/promlib/healthcheck.go
+++ b/pkg/promlib/healthcheck.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
 
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/middleware"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 )
 
@@ -31,6 +32,11 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	}
 
 	logger := s.logger.FromContext(ctx)
+
+	// healthcheck builds a synthetic QueryDataRequest without the original headers,
+	// so install FromAlert forwarding here from the real CheckHealthRequest headers,
+	// mirroring core Grafana's in-process HTTPClientMiddleware.
+	ctx = middleware.WithFromAlertForwarding(ctx, req.Headers[middleware.FromAlertHeaderName])
 
 	hc, err := healthcheck(ctx, req, ds)
 	if err != nil {

--- a/pkg/promlib/middleware/forward_alert_headers.go
+++ b/pkg/promlib/middleware/forward_alert_headers.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+// FromAlertHeaderName is the plain (non "http_"-prefixed) header the alerting
+// engine sets on the QueryDataRequest. Because it is not "http_"-prefixed it is
+// excluded from QueryDataRequest.GetHTTPHeaders(), so the SDK's generic header
+// forwarding never propagates it. We forward it explicitly instead.
+const FromAlertHeaderName = "FromAlert"
+
+const forwardAlertHeadersMiddlewareName = "prom-forward-alert-headers"
+
+// ForwardFromAlertHeader returns a contextual HTTP middleware that sets the
+// FromAlert header (with the given value) on the outgoing upstream request.
+//
+// It is meant to be installed per-request via
+// sdkhttpclient.WithContextualMiddleware when the QueryDataRequest originates
+// from alerting, mirroring core Grafana's HTTPClientMiddleware which special-cases
+// the same header. An existing FromAlert header is never overwritten.
+func ForwardFromAlertHeader(value string) sdkhttpclient.Middleware {
+	return sdkhttpclient.NamedMiddlewareFunc(forwardAlertHeadersMiddlewareName, func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		if value == "" {
+			return next
+		}
+		return sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get(FromAlertHeaderName) == "" {
+				req.Header.Set(FromAlertHeaderName, value)
+			}
+			return next.RoundTrip(req)
+		})
+	})
+}

--- a/pkg/promlib/middleware/forward_alert_headers.go
+++ b/pkg/promlib/middleware/forward_alert_headers.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -17,20 +18,29 @@ const forwardAlertHeadersMiddlewareName = "prom-forward-alert-headers"
 // ForwardFromAlertHeader returns a contextual HTTP middleware that sets the
 // FromAlert header (with the given value) on the outgoing upstream request.
 //
-// It is meant to be installed per-request via
-// sdkhttpclient.WithContextualMiddleware when the QueryDataRequest originates
-// from alerting, mirroring core Grafana's HTTPClientMiddleware which special-cases
-// the same header. An existing FromAlert header is never overwritten.
+// It is meant to be installed per-request via WithFromAlertForwarding when the
+// request originates from alerting, mirroring core Grafana's HTTPClientMiddleware
+// which special-cases the same header with an unconditional Set.
 func ForwardFromAlertHeader(value string) sdkhttpclient.Middleware {
 	return sdkhttpclient.NamedMiddlewareFunc(forwardAlertHeadersMiddlewareName, func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
 		if value == "" {
 			return next
 		}
 		return sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if req.Header.Get(FromAlertHeaderName) == "" {
-				req.Header.Set(FromAlertHeaderName, value)
-			}
+			req.Header.Set(FromAlertHeaderName, value)
 			return next.RoundTrip(req)
 		})
 	})
+}
+
+// WithFromAlertForwarding installs the FromAlert forwarding middleware on ctx when
+// value is non-empty. It is a no-op for an empty value, so callers can pass the
+// raw header value without guarding. FromAlert is forwarded ungated (independent
+// of opts.ForwardHTTPHeaders), matching core Grafana's in-process behavior; it is
+// a non-credential flag, so it carries no extra exposure.
+func WithFromAlertForwarding(ctx context.Context, value string) context.Context {
+	if value == "" {
+		return ctx
+	}
+	return sdkhttpclient.WithContextualMiddleware(ctx, ForwardFromAlertHeader(value))
 }

--- a/pkg/promlib/middleware/forward_alert_headers_test.go
+++ b/pkg/promlib/middleware/forward_alert_headers_test.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardFromAlertHeader(t *testing.T) {
+	finalRoundTripper := sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Request: req}, nil
+	})
+
+	newReq := func(t *testing.T) *http.Request {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9090", nil)
+		require.NoError(t, err)
+		return req
+	}
+
+	t.Run("sets the FromAlert header on the outgoing request", func(t *testing.T) {
+		rt := ForwardFromAlertHeader("true").CreateMiddleware(sdkhttpclient.Options{}, finalRoundTripper)
+		req := newReq(t)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, "true", req.Header.Get(FromAlertHeaderName))
+	})
+
+	t.Run("does not overwrite an existing FromAlert header", func(t *testing.T) {
+		rt := ForwardFromAlertHeader("true").CreateMiddleware(sdkhttpclient.Options{}, finalRoundTripper)
+		req := newReq(t)
+		req.Header.Set(FromAlertHeaderName, "preset")
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, "preset", req.Header.Get(FromAlertHeaderName))
+	})
+
+	t.Run("is a no-op for an empty value", func(t *testing.T) {
+		rt := ForwardFromAlertHeader("").CreateMiddleware(sdkhttpclient.Options{}, finalRoundTripper)
+		req := newReq(t)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Empty(t, req.Header.Get(FromAlertHeaderName))
+	})
+
+	t.Run("exposes a stable middleware name", func(t *testing.T) {
+		named, ok := ForwardFromAlertHeader("true").(sdkhttpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, forwardAlertHeadersMiddlewareName, named.MiddlewareName())
+	})
+}

--- a/pkg/promlib/middleware/forward_alert_headers_test.go
+++ b/pkg/promlib/middleware/forward_alert_headers_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -28,13 +29,13 @@ func TestForwardFromAlertHeader(t *testing.T) {
 		require.Equal(t, "true", req.Header.Get(FromAlertHeaderName))
 	})
 
-	t.Run("does not overwrite an existing FromAlert header", func(t *testing.T) {
+	t.Run("overwrites an existing FromAlert header (parity with core's unconditional Set)", func(t *testing.T) {
 		rt := ForwardFromAlertHeader("true").CreateMiddleware(sdkhttpclient.Options{}, finalRoundTripper)
 		req := newReq(t)
 		req.Header.Set(FromAlertHeaderName, "preset")
 		_, err := rt.RoundTrip(req)
 		require.NoError(t, err)
-		require.Equal(t, "preset", req.Header.Get(FromAlertHeaderName))
+		require.Equal(t, "true", req.Header.Get(FromAlertHeaderName))
 	})
 
 	t.Run("is a no-op for an empty value", func(t *testing.T) {
@@ -49,5 +50,22 @@ func TestForwardFromAlertHeader(t *testing.T) {
 		named, ok := ForwardFromAlertHeader("true").(sdkhttpclient.MiddlewareName)
 		require.True(t, ok)
 		require.Equal(t, forwardAlertHeadersMiddlewareName, named.MiddlewareName())
+	})
+}
+
+func TestWithFromAlertForwarding(t *testing.T) {
+	t.Run("installs the contextual middleware for a non-empty value", func(t *testing.T) {
+		ctx := WithFromAlertForwarding(context.Background(), "true")
+		mws := sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		require.Len(t, mws, 1)
+		named, ok := mws[0].(sdkhttpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, forwardAlertHeadersMiddlewareName, named.MiddlewareName())
+	})
+
+	t.Run("is a no-op for an empty value", func(t *testing.T) {
+		ctx := context.Background()
+		require.Equal(t, ctx, WithFromAlertForwarding(ctx, ""))
+		require.Empty(t, sdkhttpclient.ContextualMiddlewareFromContext(WithFromAlertForwarding(ctx, "")))
 	})
 }

--- a/pkg/promlib/querydata/alert_headers_test.go
+++ b/pkg/promlib/querydata/alert_headers_test.go
@@ -1,0 +1,189 @@
+package querydata_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/client"
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/querydata"
+)
+
+// These tests reproduce the externalization regression where alerting headers
+// (FromAlert, X-Rule-*) set on the backend.QueryDataRequest do NOT reach the
+// upstream Prometheus HTTP request when the plugin runs as an external
+// (out-of-process) backend.
+//
+// In-process, core Grafana's HTTPClientMiddleware copies these headers onto the
+// outgoing request. That middleware lives in the parent Grafana process and does
+// not cross the gRPC boundary into an external plugin. Inside the external plugin,
+// the only equivalent is the SDK's plugin-side header forwarding, which:
+//   - is installed by datasource.Manage (replicated by withSDKHeaderForwarding below),
+//   - only forwards headers exposed via req.GetHTTPHeaders() (i.e. the "http_"-prefixed
+//     ones such as http_X-Rule-*), and
+//   - only fires when the HTTP client opts in via opts.ForwardHTTPHeaders AND the
+//     client chain contains httpclient.ContextualMiddleware().
+//
+// Prometheus' CreateTransportOptions does neither today, so nothing is forwarded.
+
+// captured records the headers of the last outgoing request to the upstream.
+type captured struct {
+	mu      sync.Mutex
+	headers http.Header
+}
+
+func (c *captured) set(h http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.headers = h.Clone()
+}
+
+func (c *captured) get() http.Header {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.headers
+}
+
+// captureMiddleware is installed as the innermost HTTP client middleware so it
+// observes the request exactly as it would go out on the wire, then returns a
+// canned successful Prometheus response instead of hitting the network.
+func captureMiddleware(c *captured) httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc("test-capture", func(_ httpclient.Options, _ http.RoundTripper) http.RoundTripper {
+		return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			c.set(req.Header)
+			body := `{"status":"success","data":{"resultType":"matrix","result":[]}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+				Request:    req,
+			}, nil
+		})
+	})
+}
+
+// withSDKHeaderForwarding mirrors grafana-plugin-sdk-go's headerMiddleware
+// (backend/http_headers.go), which datasource.Manage installs for every plugin.
+// It stores a contextual HTTP middleware that forwards req.GetHTTPHeaders() to the
+// outgoing request, but only when opts.ForwardHTTPHeaders is enabled.
+func withSDKHeaderForwarding(ctx context.Context, req *backend.QueryDataRequest) context.Context {
+	headers := req.GetHTTPHeaders()
+	if len(headers) == 0 {
+		return ctx
+	}
+	return httpclient.WithContextualMiddleware(ctx,
+		httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			if !opts.ForwardHTTPHeaders {
+				return next
+			}
+			return httpclient.RoundTripperFunc(func(qreq *http.Request) (*http.Response, error) {
+				for k, v := range headers {
+					if qreq.Header.Get(k) == "" {
+						for _, vv := range v {
+							qreq.Header.Add(k, vv)
+						}
+					}
+				}
+				return next.RoundTrip(qreq)
+			})
+		}))
+}
+
+// newExternalQueryData builds a QueryData wired exactly like the external plugin
+// in pkg/datasource.go: production CreateTransportOptions + a bare SDK provider.
+// A capture middleware is appended last so it sees the final outgoing headers.
+func newExternalQueryData(t *testing.T, c *captured) *querydata.QueryData {
+	t.Helper()
+
+	settings := backend.DataSourceInstanceSettings{
+		URL:      "http://localhost:9090",
+		JSONData: []byte(`{"timeInterval":"15s"}`),
+	}
+
+	opts, err := client.CreateTransportOptions(context.Background(), settings, log.New())
+	require.NoError(t, err)
+
+	opts.Middlewares = append(opts.Middlewares, captureMiddleware(c))
+
+	httpClient, err := httpclient.NewProvider().New(*opts)
+	require.NoError(t, err)
+
+	qd, err := querydata.New(httpClient, settings, log.New(), backend.FeatureToggles{})
+	require.NoError(t, err)
+	return qd
+}
+
+func alertQueryRequest(headers map[string]string) *backend.QueryDataRequest {
+	now := time.Now()
+	return &backend.QueryDataRequest{
+		Headers: headers,
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				TimeRange: backend.TimeRange{
+					From: now.Add(-1 * time.Hour),
+					To:   now,
+				},
+				JSON: []byte(`{"expr":"up","range":true,"refId":"A","intervalMs":15000}`),
+			},
+		},
+		PluginContext: backend.PluginContext{
+			GrafanaConfig: backend.NewGrafanaCfg(map[string]string{
+				"concurrent_query_count": "10",
+			}),
+		},
+	}
+}
+
+func TestQueryData_ForwardsAlertHeadersToUpstream(t *testing.T) {
+	ctx := backend.WithGrafanaConfig(context.Background(), backend.NewGrafanaCfg(map[string]string{
+		"concurrent_query_count": "10",
+	}))
+
+	// ngalert sets rule metadata as "http_X-Rule-*" and FromAlert as a plain key.
+	headers := map[string]string{
+		"FromAlert":        "true",
+		"http_X-Rule-Uid":  "rule-abc-123",
+		"http_X-Rule-Name": "High error rate",
+	}
+
+	t.Run("forwards X-Rule-* headers to the upstream Prometheus request", func(t *testing.T) {
+		c := &captured{}
+		qd := newExternalQueryData(t, c)
+
+		req := alertQueryRequest(headers)
+		reqCtx := withSDKHeaderForwarding(ctx, req)
+
+		_, err := qd.Execute(reqCtx, req)
+		require.NoError(t, err)
+
+		got := c.get()
+		require.NotNil(t, got, "no upstream request was captured")
+		require.Equal(t, "rule-abc-123", got.Get("X-Rule-Uid"), "X-Rule-Uid must be forwarded to the upstream Prometheus")
+		require.Equal(t, "High error rate", got.Get("X-Rule-Name"), "X-Rule-Name must be forwarded to the upstream Prometheus")
+	})
+
+	t.Run("forwards FromAlert header to the upstream Prometheus request", func(t *testing.T) {
+		c := &captured{}
+		qd := newExternalQueryData(t, c)
+
+		req := alertQueryRequest(headers)
+		reqCtx := withSDKHeaderForwarding(ctx, req)
+
+		_, err := qd.Execute(reqCtx, req)
+		require.NoError(t, err)
+
+		got := c.get()
+		require.NotNil(t, got, "no upstream request was captured")
+		require.Equal(t, "true", got.Get("FromAlert"), "FromAlert must be forwarded to the upstream Prometheus")
+	})
+}

--- a/pkg/promlib/querydata/alert_headers_test.go
+++ b/pkg/promlib/querydata/alert_headers_test.go
@@ -100,7 +100,8 @@ func withSDKHeaderForwarding(ctx context.Context, req *backend.QueryDataRequest)
 
 // newExternalQueryData builds a QueryData wired exactly like the external plugin
 // in pkg/datasource.go: production CreateTransportOptions + a bare SDK provider.
-// A capture middleware is appended last so it sees the final outgoing headers.
+// A capture middleware is installed as the innermost middleware so it sees the
+// final outgoing headers (after the SDK's ContextualMiddleware has applied them).
 func newExternalQueryData(t *testing.T, c *captured) *querydata.QueryData {
 	t.Helper()
 
@@ -112,7 +113,15 @@ func newExternalQueryData(t *testing.T, c *captured) *querydata.QueryData {
 	opts, err := client.CreateTransportOptions(context.Background(), settings, log.New())
 	require.NoError(t, err)
 
-	opts.Middlewares = append(opts.Middlewares, captureMiddleware(c))
+	// httpclient.NewProvider().New appends DefaultMiddlewares() (incl.
+	// ContextualMiddleware, which applies the forwarded headers) AFTER
+	// opts.Middlewares. To observe the request exactly as it leaves for the
+	// upstream, install the capture middleware as the very last (innermost)
+	// middleware via ConfigureMiddleware, so it runs after the forwarding has
+	// happened.
+	opts.ConfigureMiddleware = func(_ httpclient.Options, existing []httpclient.Middleware) []httpclient.Middleware {
+		return append(existing, captureMiddleware(c))
+	}
 
 	httpClient, err := httpclient.NewProvider().New(*opts)
 	require.NoError(t, err)

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/client"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/intervalv2"
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/middleware"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/querydata/exemplar"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/utils"
@@ -93,9 +95,17 @@ func New(
 }
 
 func (s *QueryData) Execute(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	fromAlert := req.Headers["FromAlert"] == "true"
+	fromAlert := req.Headers[middleware.FromAlertHeaderName] == "true"
 	logger := s.log.FromContext(ctx)
 	logger.Debug("Begin query execution", "fromAlert", fromAlert)
+
+	// FromAlert is a plain header excluded from GetHTTPHeaders(), so the SDK's
+	// generic forwarding never propagates it to the upstream Prometheus. Forward it
+	// explicitly via a contextual middleware (applied by ContextualMiddleware in the
+	// client chain), mirroring core Grafana's in-process HTTPClientMiddleware.
+	if v := req.Headers[middleware.FromAlertHeaderName]; v != "" {
+		ctx = sdkhttpclient.WithContextualMiddleware(ctx, middleware.ForwardFromAlertHeader(v))
+	}
 	result := backend.QueryDataResponse{
 		Responses: backend.Responses{},
 	}

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -103,9 +102,7 @@ func (s *QueryData) Execute(ctx context.Context, req *backend.QueryDataRequest) 
 	// generic forwarding never propagates it to the upstream Prometheus. Forward it
 	// explicitly via a contextual middleware (applied by ContextualMiddleware in the
 	// client chain), mirroring core Grafana's in-process HTTPClientMiddleware.
-	if v := req.Headers[middleware.FromAlertHeaderName]; v != "" {
-		ctx = sdkhttpclient.WithContextualMiddleware(ctx, middleware.ForwardFromAlertHeader(v))
-	}
+	ctx = middleware.WithFromAlertForwarding(ctx, req.Headers[middleware.FromAlertHeaderName])
 	result := backend.QueryDataResponse{
 		Responses: backend.Responses{},
 	}

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/client"
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/middleware"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/utils"
 )
@@ -49,6 +50,16 @@ func New(
 
 func (r *Resource) Execute(ctx context.Context, req *backend.CallResourceRequest) (*backend.CallResourceResponse, error) {
 	r.log.FromContext(ctx).Debug("Sending resource query", "URL", req.URL)
+
+	// CallResourceRequest.Headers is map[string][]string, and FromAlert is a plain
+	// (non "http_"-prefixed) key the SDK's generic forwarding never propagates.
+	// Forward it explicitly, mirroring core Grafana's in-process HTTPClientMiddleware.
+	var fromAlert string
+	if vals := req.Headers[middleware.FromAlertHeaderName]; len(vals) > 0 {
+		fromAlert = vals[0]
+	}
+	ctx = middleware.WithFromAlertForwarding(ctx, fromAlert)
+
 	resp, err := r.promClient.QueryResource(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("error querying resource: %v", err)


### PR DESCRIPTION
This header is needed to be in parity with [core grafana](https://github.com/grafana/grafana/blob/300c50f072032a6a5426785ad57bc07deb3f7b79/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go). [DefaultMiddlewares](https://github.com/grafana/grafana-plugin-sdk-go/blob/v0.292.1/backend/httpclient/http_client.go#L226-L240) in grafana-plugin-sdk-go doesn't have such middleware. 

**Note:** 
If https://github.com/grafana/grafana-plugin-sdk-go/pull/1583 wil be merged then we don't need this PR.