### PR TITLE
fix: forward Grafana HTTP headers (X-Dashboard-*, X-Grafana-*) to upstream database

### DIFF
--- a/.changeset/forty-pandas-grow.md
+++ b/.changeset/forty-pandas-grow.md
@@ -1,0 +1,5 @@
+---
+'promlib': patch
+---
+
+Enable forwarding http headers

--- a/pkg/promlib/client/transport.go
+++ b/pkg/promlib/client/transport.go
@@ -33,5 +33,12 @@ func CreateTransportOptions(ctx context.Context, settings backend.DataSourceInst
 	}
 	opts.Middlewares = middlewares
 
+	// Forward Grafana-provided HTTP headers (e.g. FromAlert, X-Rule-*, X-Dashboard-*,
+	// X-Panel-*, X-Grafana-Org-Id, X-Grafana-User) to the outgoing datasource request.
+	// When running as an external plugin, Grafana's in-process header-forwarding
+	// middleware does not cross the gRPC boundary, so the SDK's header middleware must
+	// do the forwarding here.
+	opts.ForwardHTTPHeaders = true
+
 	return &opts, nil
 }

--- a/pkg/promlib/client/transport_test.go
+++ b/pkg/promlib/client/transport_test.go
@@ -24,4 +24,10 @@ func TestCreateTransportOptions(t *testing.T) {
 		require.Equal(t, http.Header{"Foo": []string{"bar"}}, opts.Header)
 		require.Equal(t, 1, len(opts.Middlewares))
 	})
+
+	t.Run("enables ForwardHTTPHeaders so Grafana headers (FromAlert, X-Rule-*, X-Dashboard-*, X-Panel-*, X-Grafana-*) are forwarded to the datasource", func(t *testing.T) {
+		opts, err := CreateTransportOptions(context.Background(), backend.DataSourceInstanceSettings{}, backend.NewLoggerWith("logger", "test"))
+		require.NoError(t, err)
+		require.True(t, opts.ForwardHTTPHeaders)
+	})
 }


### PR DESCRIPTION
## What / why
Sets `ForwardHTTPHeaders = true` on the Prometheus HTTP client so Grafana's query headers (`X-Rule-*`, `X-Dashboard-*`, `X-Panel-*`, `X-Grafana-Org-Id`, `X-Grafana-User`) reach Prometheus/Mimir.

In core we had those middlewares already 
https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go

This matches what Loki and Pyroscope already do. See https://github.com/grafana/grafana/pull/90890
`FromAlert` is handled separately by the SDK's `AlertForwarderMiddleware`.
