### PR TITLE
fix: associate operation parameter labels with inputs

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderContainer.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderContainer.test.tsx
@@ -33,6 +33,12 @@ describe('PromQueryBuilderContainer', () => {
       expect(container.querySelector(`${getOperationParamId('0', 0)}`)).toBeInTheDocument();
     });
   });
+
+  it('associates operation parameter labels with their controls', () => {
+    setup({ expr: 'rate(metric_test[5m])' });
+
+    expect(screen.getByLabelText('Range')).toBeInTheDocument();
+  });
 });
 
 function setup(queryOverrides: Partial<PromQuery> = {}) {

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -104,7 +104,7 @@ export function OperationEditor({
               paramDef={paramDef}
               value={operation.params[paramIndex]}
               index={paramIndex}
-              operationId={operation.id}
+              operationId={id}
               query={query}
               datasource={datasource}
               timeRange={timeRange}

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
@@ -150,7 +150,7 @@ function SelectInputParamEditor({
   return (
     <Stack gap={0.5} direction="row" alignItems="center">
       <Select
-        id={getOperationParamId(operationId, index)}
+        inputId={getOperationParamId(operationId, index)}
         value={valueOption}
         options={selectOptions}
         placeholder={paramDef.placeholder}


### PR DESCRIPTION
## What this PR does

Fixes the Prometheus visual query builder operation parameter labels so they point to the actual form controls.

The operation editor generated one ID for `<label htmlFor=...>`, but passed a different operation ID to the parameter editor. For `Select`-based parameters, the code also passed `id` instead of `inputId`, so the underlying combobox kept the generated `react-select-*` input ID instead of the label target.

This updates the operation editor to pass the same generated ID through to parameter editors and uses `inputId` for `Select` controls. It also adds a regression test for the `Range` parameter.

Related to grafana/grafana#66347.

## Testing

```console
git diff --check
```

I could not run the Jest test locally in this checkout because dependencies are not installed and the environment does not have the repo-pinned Yarn/Corepack available. The added test is scoped to the changed behavior: `screen.getByLabelText('Range')` should fail before this fix and pass after the label/control IDs match.
