### PR TITLE
feat: interactions for explorer and metrics browser

### DIFF
--- a/.changeset/quick-times-exist.md
+++ b/.changeset/quick-times-exist.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add interaction tracking for Query Explorer and Metrics Browser

--- a/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import { DEFAULT_SERIES_LIMIT, METRIC_LABEL } from '../../constants';
+import { type PrometheusDatasource } from '../../datasource';
+import { type PrometheusLanguageProviderInterface } from '../../language_provider';
+import { getMockTimeRange } from '../../test/mocks/datasource';
+
+import { LabelSelector } from './LabelSelector';
+import { MetricsBrowserProvider } from './MetricsBrowserContext';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+function createLanguageProvider(): PrometheusLanguageProviderInterface {
+  const mockLanguageProvider = {
+    retrieveMetricsMetadata: () => ({}),
+    queryLabelKeys: jest.fn().mockResolvedValue(['job', 'instance', 'service']),
+    queryLabelValues: jest.fn().mockImplementation((_timeRange: TimeRange, label: string) => {
+      if (label === METRIC_LABEL) {
+        return Promise.resolve(['metric_one']);
+      }
+      return Promise.resolve([]);
+    }),
+  } as unknown as PrometheusLanguageProviderInterface;
+  mockLanguageProvider.datasource = { seriesLimit: DEFAULT_SERIES_LIMIT } as unknown as PrometheusDatasource;
+  return mockLanguageProvider;
+}
+
+function setup() {
+  render(
+    <MetricsBrowserProvider timeRange={getMockTimeRange()} languageProvider={createLanguageProvider()} onChange={jest.fn()}>
+      <LabelSelector />
+    </MetricsBrowserProvider>
+  );
+}
+
+describe('LabelSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports an interaction when a label search is performed', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('job')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByLabelText('Filter expression for label');
+    await userEvent.type(searchInput, 'job');
+
+    await waitFor(
+      () => {
+        expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_label_search_performed', {
+          searchQuery: 'job',
+          resultsCount: 1,
+        });
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
+import { useDebounce } from 'react-use';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { BrowserLabel as PromLabel, Input, Label, useStyles2, Spinner } from '@grafana/ui';
 
 import { METRIC_LABEL } from '../../constants';
@@ -20,6 +22,19 @@ export function LabelSelector() {
       (lk) => lk !== METRIC_LABEL && (selectedLabelKeys.includes(lk) || lk.includes(labelSearchTerm))
     );
   }, [labelKeys, labelSearchTerm, selectedLabelKeys]);
+
+  useDebounce(
+    () => {
+      if (labelSearchTerm) {
+        reportInteraction('grafana_prometheus_metrics_browser_label_search_performed', {
+          searchQuery: labelSearchTerm,
+          resultsCount: filteredLabelKeys.length,
+        });
+      }
+    },
+    500,
+    [labelSearchTerm]
+  );
 
   return (
     <div className={styles.section}>

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import { DEFAULT_SERIES_LIMIT, METRIC_LABEL } from '../../constants';
+import { type PrometheusDatasource } from '../../datasource';
+import { type PrometheusLanguageProviderInterface } from '../../language_provider';
+import { getMockTimeRange } from '../../test/mocks/datasource';
+
+import { MetricSelector } from './MetricSelector';
+import { MetricsBrowserProvider } from './MetricsBrowserContext';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+function createLanguageProvider(): PrometheusLanguageProviderInterface {
+  const mockLanguageProvider = {
+    retrieveMetricsMetadata: () => ({}),
+    queryLabelKeys: jest.fn().mockResolvedValue([]),
+    queryLabelValues: jest.fn().mockImplementation((_timeRange: TimeRange, label: string) => {
+      if (label === METRIC_LABEL) {
+        return Promise.resolve(['metric_one', 'metric_two', 'metric_three']);
+      }
+      return Promise.resolve([]);
+    }),
+  } as unknown as PrometheusLanguageProviderInterface;
+  mockLanguageProvider.datasource = { seriesLimit: DEFAULT_SERIES_LIMIT } as unknown as PrometheusDatasource;
+  return mockLanguageProvider;
+}
+
+function setup() {
+  render(
+    <MetricsBrowserProvider timeRange={getMockTimeRange()} languageProvider={createLanguageProvider()} onChange={jest.fn()}>
+      <MetricSelector />
+    </MetricsBrowserProvider>
+  );
+}
+
+describe('MetricSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports an interaction when a metric search is performed', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('metric_one')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByLabelText('Filter expression for metric');
+    await userEvent.type(searchInput, 'metric_o');
+
+    await waitFor(
+      () => {
+        expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_metric_search_performed', {
+          searchQuery: 'metric_o',
+          resultsCount: 1,
+        });
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  it('does not report an interaction for an empty search', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('metric_one')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByLabelText('Filter expression for metric');
+    await userEvent.type(searchInput, 'x');
+    await userEvent.clear(searchInput);
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(reportInteraction).not.toHaveBeenCalledWith(
+      'grafana_prometheus_metrics_browser_metric_search_performed',
+      expect.objectContaining({ searchQuery: '' })
+    );
+  });
+});

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
+import { useDebounce } from 'react-use';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { BrowserLabel as PromLabel, Input, Label, useStyles2 } from '@grafana/ui';
 
 import { LIST_ITEM_SIZE } from '../../constants';
@@ -18,6 +20,19 @@ export function MetricSelector() {
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
   }, [metrics, selectedMetric, metricSearchTerm]);
+
+  useDebounce(
+    () => {
+      if (metricSearchTerm) {
+        reportInteraction('grafana_prometheus_metrics_browser_metric_search_performed', {
+          searchQuery: metricSearchTerm,
+          resultsCount: filteredMetrics.length,
+        });
+      }
+    },
+    500,
+    [metricSearchTerm]
+  );
 
   return (
     <div>

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event';
 import { type ReactNode } from 'react';
 
 import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { DEFAULT_SERIES_LIMIT, LAST_USED_LABELS_KEY, METRIC_LABEL } from '../../constants';
 import { type PrometheusDatasource } from '../../datasource';
@@ -10,6 +11,11 @@ import { type PrometheusLanguageProviderInterface } from '../../language_provide
 import { getMockTimeRange } from '../../test/mocks/datasource';
 
 import { MetricsBrowserProvider, useMetricsBrowser } from './MetricsBrowserContext';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
 
 const setupLocalStorageMock = () => {
   let store: Record<string, string> = {};
@@ -413,6 +419,87 @@ describe('MetricsBrowserContext', () => {
         expect(screen.getByTestId('selected-label-keys').textContent).toBe('');
         expect(screen.getByTestId('selector').textContent).toBe('{}');
       });
+    });
+  });
+
+  describe('interaction tracking', () => {
+    it('reports select and deselect for a metric click', async () => {
+      const user = userEvent.setup();
+      const { renderWithProvider } = setupTest();
+      renderWithProvider(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metrics-count').textContent).toBe('3');
+      });
+
+      await user.click(screen.getByTestId('select-metric'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_metric_clicked', {
+        action: 'selected',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-metric').textContent).toBe('metric1');
+      });
+
+      await user.click(screen.getByTestId('select-metric'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_metric_clicked', {
+        action: 'deselected',
+      });
+    });
+
+    it('reports select and deselect for a label key click', async () => {
+      const user = userEvent.setup();
+      const { renderWithProvider } = setupTest();
+      renderWithProvider(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metrics-count').textContent).toBe('3');
+      });
+
+      await user.click(screen.getByTestId('select-label'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_label_key_clicked', {
+        action: 'selected',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-label-keys').textContent).toBe('job');
+      });
+
+      await user.click(screen.getByTestId('select-label'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_label_key_clicked', {
+        action: 'deselected',
+      });
+    });
+
+    it('reports selected for a label value click', async () => {
+      const user = userEvent.setup();
+      const { renderWithProvider } = setupTest();
+      renderWithProvider(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metrics-count').textContent).toBe('3');
+      });
+
+      await user.click(screen.getByTestId('select-label-value'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_label_value_clicked', {
+        action: 'selected',
+      });
+    });
+
+    it('reports validate and clear clicks', async () => {
+      const user = userEvent.setup();
+      const { renderWithProvider } = setupTest();
+      renderWithProvider(<TestComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metrics-count').textContent).toBe('3');
+      });
+
+      await user.click(screen.getByTestId('validate'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_validate_clicked');
+
+      await user.click(screen.getByTestId('clear'));
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_clear_clicked');
     });
   });
 

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, type PropsWithChildren, useCallback, useContext, useMemo } from 'react';
 
 import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { type PrometheusLanguageProviderInterface } from '../../language_provider';
 
@@ -99,6 +100,46 @@ export function MetricsBrowserProvider({
     [selectedLabelValues, selectedMetric]
   );
 
+  const onMetricClick = useCallback(
+    (name: string) => {
+      reportInteraction('grafana_prometheus_metrics_browser_metric_clicked', {
+        action: selectedMetric === name ? 'deselected' : 'selected',
+      });
+      return handleSelectedMetricChange(name);
+    },
+    [handleSelectedMetricChange, selectedMetric]
+  );
+
+  const onLabelKeyClick = useCallback(
+    (name: string) => {
+      reportInteraction('grafana_prometheus_metrics_browser_label_key_clicked', {
+        action: selectedLabelKeys.includes(name) ? 'deselected' : 'selected',
+      });
+      return handleSelectedLabelKeyChange(name);
+    },
+    [handleSelectedLabelKeyChange, selectedLabelKeys]
+  );
+
+  const onLabelValueClick = useCallback(
+    (labelKey: string, labelValue: string, isSelected: boolean) => {
+      reportInteraction('grafana_prometheus_metrics_browser_label_value_clicked', {
+        action: isSelected ? 'selected' : 'deselected',
+      });
+      return handleSelectedLabelValueChange(labelKey, labelValue, isSelected);
+    },
+    [handleSelectedLabelValueChange]
+  );
+
+  const onValidationClick = useCallback(() => {
+    reportInteraction('grafana_prometheus_metrics_browser_validate_clicked');
+    return handleValidation();
+  }, [handleValidation]);
+
+  const onClearClick = useCallback(() => {
+    reportInteraction('grafana_prometheus_metrics_browser_clear_clicked');
+    return handleClear();
+  }, [handleClear]);
+
   // Memoize the context value to prevent unnecessary re-renders
   const value = useMemo(
     () => ({
@@ -119,11 +160,11 @@ export function MetricsBrowserProvider({
       selectedMetric,
       selectedLabelKeys,
       selectedLabelValues,
-      onMetricClick: handleSelectedMetricChange,
-      onLabelKeyClick: handleSelectedLabelKeyChange,
-      onLabelValueClick: handleSelectedLabelValueChange,
-      onValidationClick: handleValidation,
-      onClearClick: handleClear,
+      onMetricClick,
+      onLabelKeyClick,
+      onLabelValueClick,
+      onValidationClick,
+      onClearClick,
     }),
     [
       err,
@@ -143,11 +184,11 @@ export function MetricsBrowserProvider({
       selectedMetric,
       selectedLabelKeys,
       selectedLabelValues,
-      handleSelectedMetricChange,
-      handleSelectedLabelKeyChange,
-      handleSelectedLabelValueChange,
-      handleValidation,
-      handleClear,
+      onMetricClick,
+      onLabelKeyClick,
+      onLabelValueClick,
+      onValidationClick,
+      onClearClick,
     ]
   );
 

--- a/packages/grafana-prometheus/src/components/metrics-browser/SelectorActions.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/SelectorActions.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import { DEFAULT_SERIES_LIMIT, LAST_USED_LABELS_KEY, METRIC_LABEL } from '../../constants';
+import { type PrometheusDatasource } from '../../datasource';
+import { type PrometheusLanguageProviderInterface } from '../../language_provider';
+import { getMockTimeRange } from '../../test/mocks/datasource';
+
+import { MetricsBrowserProvider } from './MetricsBrowserContext';
+import { SelectorActions } from './SelectorActions';
+import { ValueSelector } from './ValueSelector';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+function createLanguageProvider(): PrometheusLanguageProviderInterface {
+  const mockLanguageProvider = {
+    retrieveMetricsMetadata: () => ({}),
+    queryLabelKeys: jest.fn().mockResolvedValue(['job']),
+    queryLabelValues: jest.fn().mockImplementation((_timeRange: TimeRange, label: string) => {
+      if (label === METRIC_LABEL) {
+        return Promise.resolve(['metric_one']);
+      }
+      if (label === 'job') {
+        return Promise.resolve(['grafana']);
+      }
+      return Promise.resolve([]);
+    }),
+  } as unknown as PrometheusLanguageProviderInterface;
+  mockLanguageProvider.datasource = { seriesLimit: DEFAULT_SERIES_LIMIT } as unknown as PrometheusDatasource;
+  return mockLanguageProvider;
+}
+
+async function setup(onChange = jest.fn()) {
+  // pre-select the "job" label key so its values are loaded, then select a value below
+  // to give the selector something non-empty for the action buttons to operate on
+  localStorage.setItem(LAST_USED_LABELS_KEY, JSON.stringify(['job']));
+
+  render(
+    <MetricsBrowserProvider timeRange={getMockTimeRange()} languageProvider={createLanguageProvider()} onChange={onChange}>
+      <ValueSelector />
+      <SelectorActions />
+    </MetricsBrowserProvider>
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText('grafana')).toBeInTheDocument();
+  });
+  await userEvent.click(screen.getByText('grafana'));
+
+  return { onChange };
+}
+
+describe('SelectorActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('reports an interaction when the selector is used as a query', async () => {
+    await setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /use selector for query button/i })).toBeEnabled();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /use selector for query button/i }));
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_query_applied', {
+      asRateQuery: false,
+    });
+  });
+
+  it('reports an interaction when the selector is used as a rate query', async () => {
+    await setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /use selector as metrics button/i })).toBeEnabled();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /use selector as metrics button/i }));
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_query_applied', {
+      asRateQuery: true,
+    });
+  });
+});

--- a/packages/grafana-prometheus/src/components/metrics-browser/SelectorActions.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/SelectorActions.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, Label, Stack, useStyles2 } from '@grafana/ui';
 
 import { EMPTY_SELECTOR } from '../../constants';
@@ -17,10 +18,12 @@ export function SelectorActions() {
   const selector = getSelector();
 
   const onClickRunQuery = () => {
+    reportInteraction('grafana_prometheus_metrics_browser_query_applied', { asRateQuery: false });
     onChange(selector);
   };
 
   const onClickRunRateQuery = () => {
+    reportInteraction('grafana_prometheus_metrics_browser_query_applied', { asRateQuery: true });
     const query = `rate(${selector}[$__rate_interval])`;
     onChange(query);
   };

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import { DEFAULT_SERIES_LIMIT, LAST_USED_LABELS_KEY, METRIC_LABEL } from '../../constants';
+import { type PrometheusDatasource } from '../../datasource';
+import { type PrometheusLanguageProviderInterface } from '../../language_provider';
+import { getMockTimeRange } from '../../test/mocks/datasource';
+
+import { MetricsBrowserProvider } from './MetricsBrowserContext';
+import { ValueSelector } from './ValueSelector';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+function createLanguageProvider(): PrometheusLanguageProviderInterface {
+  const mockLanguageProvider = {
+    retrieveMetricsMetadata: () => ({}),
+    queryLabelKeys: jest.fn().mockResolvedValue(['job']),
+    queryLabelValues: jest.fn().mockImplementation((_timeRange: TimeRange, label: string) => {
+      if (label === METRIC_LABEL) {
+        return Promise.resolve(['metric_one']);
+      }
+      if (label === 'job') {
+        return Promise.resolve(['grafana', 'prometheus']);
+      }
+      return Promise.resolve([]);
+    }),
+  } as unknown as PrometheusLanguageProviderInterface;
+  mockLanguageProvider.datasource = { seriesLimit: DEFAULT_SERIES_LIMIT } as unknown as PrometheusDatasource;
+  return mockLanguageProvider;
+}
+
+function setup() {
+  // pre-select the "job" label key so its values are loaded on init, without needing to drive LabelSelector
+  localStorage.setItem(LAST_USED_LABELS_KEY, JSON.stringify(['job']));
+
+  render(
+    <MetricsBrowserProvider timeRange={getMockTimeRange()} languageProvider={createLanguageProvider()} onChange={jest.fn()}>
+      <ValueSelector />
+    </MetricsBrowserProvider>
+  );
+}
+
+describe('ValueSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('reports an interaction with result counts but not the raw search text when a value search is performed', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('grafana')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByLabelText('Filter expression for label values');
+    await userEvent.type(searchInput, 'grafana');
+
+    await waitFor(
+      () => {
+        expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_browser_value_search_performed', {
+          resultsCount: 1,
+        });
+      },
+      { timeout: 2000 }
+    );
+
+    // the search text itself must never be sent, since label values can carry sensitive/high-cardinality data
+    for (const [, payload] of jest.mocked(reportInteraction).mock.calls) {
+      expect(JSON.stringify(payload ?? {})).not.toContain('grafana');
+    }
+  });
+});

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
+import { useDebounce } from 'react-use';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { BrowserLabel as PromLabel, Input, Label, useStyles2, Spinner } from '@grafana/ui';
 
 import { LIST_ITEM_SIZE } from '../../constants';
@@ -27,6 +29,18 @@ export function ValueSelector() {
     }
     setFilteredLabelValues(filtered);
   }, [labelValues, valueSearchTerm]);
+
+  useDebounce(
+    () => {
+      if (valueSearchTerm) {
+        // Label values may contain sensitive/high-cardinality data, so we only track result counts, not the search text itself.
+        const resultsCount = Object.values(filteredLabelValues).reduce((sum, values) => sum + values.length, 0);
+        reportInteraction('grafana_prometheus_metrics_browser_value_search_performed', { resultsCount });
+      }
+    },
+    500,
+    [valueSearchTerm]
+  );
 
   return (
     <div className={styles.section}>

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -164,4 +164,36 @@ describe('MetricCombobox', () => {
       hasSelectedMetric: false,
     });
   });
+
+  it('does not open the explorer or report an interaction when metrics lookups are disabled', async () => {
+    const lookupsDisabledDatasource = new PrometheusDatasource(
+      {
+        ...instanceSettings,
+        jsonData: { ...instanceSettings.jsonData, disableMetricsLookup: true },
+      } as unknown as DataSourceInstanceSettings<PromOptions>,
+      undefined,
+      mockLanguageProvider
+    );
+
+    render(
+      <MetricCombobox
+        {...defaultProps}
+        datasource={lookupsDisabledDatasource}
+        onGetMetrics={() => Promise.resolve([])}
+      />
+    );
+
+    // the button has a tooltip, so @grafana/ui's Button renders aria-disabled (not the native
+    // disabled attribute) to keep the tooltip interactive - but its onClick is still a no-op
+    const button = screen.getByRole('button', { name: /open metrics explorer/i });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(button);
+
+    expect(screen.queryByText('Metrics explorer')).not.toBeInTheDocument();
+    expect(reportInteraction).not.toHaveBeenCalledWith(
+      'grafana_prometheus_metrics_explorer_opened',
+      expect.anything()
+    );
+  });
 });

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../datasource';
 import { type PrometheusLanguageProviderInterface } from '../../language_provider';
@@ -12,6 +13,11 @@ import { getMockTimeRange } from '../../test/mocks/datasource';
 import { type PromOptions } from '../../types';
 
 import { MetricCombobox, type MetricComboboxProps } from './MetricCombobox';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
 
 describe('MetricCombobox', () => {
   beforeAll(() => {
@@ -146,5 +152,16 @@ describe('MetricCombobox', () => {
     await userEvent.click(button);
 
     expect(screen.getByText('Metrics explorer')).toBeInTheDocument();
+  });
+
+  it('reports an interaction when the metrics explorer is opened', async () => {
+    render(<MetricCombobox {...defaultProps} onGetMetrics={() => Promise.resolve([])} />);
+
+    const button = screen.getByRole('button', { name: /open metrics explorer/i });
+    await userEvent.click(button);
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_explorer_opened', {
+      hasSelectedMetric: false,
+    });
   });
 });

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -106,6 +106,7 @@ export function MetricCombobox({
           variant="secondary"
           icon="book-open"
           className={styles.button}
+          disabled={datasource.lookupsDisabled}
           onClick={() => {
             reportInteraction('grafana_prometheus_metrics_explorer_opened', {
               hasSelectedMetric: !!query.metric,

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -5,6 +5,7 @@ import { type GrafanaTheme2, type SelectableValue, type TimeRange } from '@grafa
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, InlineField, InlineFieldRow, Combobox, type ComboboxOption, useTheme2 } from '@grafana/ui';
 
 import { METRIC_LABEL } from '../../constants';
@@ -105,7 +106,12 @@ export function MetricCombobox({
           variant="secondary"
           icon="book-open"
           className={styles.button}
-          onClick={() => setMetricsModalOpen(true)}
+          onClick={() => {
+            reportInteraction('grafana_prometheus_metrics_explorer_opened', {
+              hasSelectedMetric: !!query.metric,
+            });
+            setMetricsModalOpen(true);
+          }}
         />
       </div>
     );

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../../datasource';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
@@ -14,7 +15,6 @@ import { type PromVisualQuery } from '../../types';
 import { MetricsModal } from './MetricsModal';
 import { metricsModaltestIds } from './testIds';
 
-// don't care about interaction tracking in our unit tests
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   reportInteraction: jest.fn(),
@@ -80,6 +80,23 @@ describe('MetricsModal', () => {
     expect(screen.getByText('all-metrics-help')).toBeInTheDocument();
   });
 
+  it('reports an interaction when a metric is selected', async () => {
+    jest.mocked(reportInteraction).mockClear();
+    setup(defaultQuery, listOfMetrics);
+    await waitFor(() => {
+      expect(screen.getByText('all-metrics')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('all-metrics'));
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_explorer_metric_selected', {
+      hasType: true,
+      searchQuery: '',
+      selectedTypesCount: 0,
+      pageNum: 1,
+    });
+  });
+
   // Filtering
   it('has a filter for selected type', async () => {
     setup(defaultQuery, listOfMetrics);
@@ -139,6 +156,26 @@ describe('MetricsModal', () => {
     });
   });
 
+  it('reports an interaction when a search is performed', async () => {
+    jest.mocked(reportInteraction).mockClear();
+    setup(defaultQuery, listOfMetrics);
+    await waitFor(() => {
+      expect(screen.getByText('a_bucket')).toBeInTheDocument();
+    });
+
+    const searchMetric = screen.getByTestId(metricsModaltestIds.searchMetric);
+    await userEvent.type(searchMetric, 'a_buck');
+
+    // the mocked language provider's queryLabelValues resolves to [] (see EmptyLanguageProviderMock),
+    // so the backend search always comes back empty regardless of the search term
+    await waitFor(() => {
+      expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_explorer_search_performed', {
+        searchQuery: 'a_buck',
+        resultsCount: 0,
+      });
+    });
+  });
+
   it('searches by name and description with a fuzzy search when setting is turned on', async () => {
     // search for a_bucket by metadata type counter but only type countt
     setup(defaultQuery, listOfMetrics);
@@ -189,6 +226,50 @@ describe('MetricsModal', () => {
     const nativeHistogram = await screen.getByText('new_histogram');
 
     expect(nativeHistogram).toBeInTheDocument();
+  });
+
+  it('reports an interaction when the type filter changes', async () => {
+    jest.mocked(reportInteraction).mockClear();
+    setup(defaultQuery, listOfMetrics);
+
+    const selectType = screen.getByText('Filter by type');
+    await userEvent.click(selectType);
+
+    const nativeHistogramOption = await screen.getByText('Native histograms are different', { exact: false });
+    await userEvent.click(nativeHistogramOption);
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_explorer_type_filter_changed', {
+      selectedTypes: 'native histogram',
+      selectedTypesCount: 1,
+    });
+  });
+
+  it('reports an interaction when the page changes', async () => {
+    jest.mocked(reportInteraction).mockClear();
+
+    // more than one page (DEFAULT_RESULTS_PER_PAGE = 25) of results, so pagination controls are rendered
+    const manyMetricsMetadata: Record<string, { type: string; help: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      manyMetricsMetadata[`metric_${i}`] = { type: 'counter', help: `metric_${i} help` };
+    }
+    const datasource = createDatasource();
+    datasource.languageProvider.queryMetricsMetadata = jest.fn().mockResolvedValue(manyMetricsMetadata);
+    datasource.languageProvider.retrieveMetricsMetadata = jest.fn().mockReturnValue(manyMetricsMetadata);
+    const props = createProps(defaultQuery, datasource, []);
+
+    render(<MetricsModal {...props} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('metric_0')).toBeInTheDocument();
+    });
+
+    const nextPageButton = screen.getByRole('button', { name: '2' });
+    await userEvent.click(nextPageButton);
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_prometheus_metrics_explorer_page_changed', {
+      pageNum: 2,
+      totalPageNum: 2,
+    });
   });
 });
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -4,6 +4,7 @@ import { cx } from '@emotion/css';
 import { type SelectableValue, type TimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Icon, Input, Modal, MultiSelect, Pagination, Spinner, useStyles2 } from '@grafana/ui';
 
 import { type PrometheusDatasource } from '../../../datasource';
@@ -92,7 +93,13 @@ const MetricsModalContent = (props: MetricsModalProps) => {
             options={typeOptions}
             value={selectedTypes}
             placeholder={placeholders.filterType}
-            onChange={setSelectedTypes}
+            onChange={(value) => {
+              reportInteraction('grafana_prometheus_metrics_explorer_type_filter_changed', {
+                selectedTypes: value.map((v) => v.value ?? '').join(','),
+                selectedTypesCount: value.length,
+              });
+              setSelectedTypes(value);
+            }}
           />
         </div>
         <div>
@@ -129,7 +136,14 @@ const MetricsModalContent = (props: MetricsModalProps) => {
         <Pagination
           currentPage={pagination.pageNum > pagination.totalPageNum ? 1 : pagination.pageNum}
           numberOfPages={pagination.totalPageNum}
-          onNavigate={(val: number) => setPagination({ ...pagination, pageNum: val ?? 1 })}
+          onNavigate={(val: number) => {
+            const pageNum = val ?? 1;
+            reportInteraction('grafana_prometheus_metrics_explorer_page_changed', {
+              pageNum,
+              totalPageNum: pagination.totalPageNum,
+            });
+            setPagination({ ...pagination, pageNum });
+          }}
         />
       </div>
     </Modal>

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 
 import { type SelectableValue, type TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { METRIC_LABEL, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
@@ -161,6 +162,11 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
 
           const [fuzzyOrderedMetrics] = fuzzySearch(results, queryString);
           const resultsOptions: MetricsData = fuzzyOrderedMetrics.map((m) => generateMetricData(m, languageProvider));
+
+          reportInteraction('grafana_prometheus_metrics_explorer_search_performed', {
+            searchQuery: metricText,
+            resultsCount: resultsOptions.length,
+          });
 
           setMetricsData(resultsOptions);
           setIsLoading(false);

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/ResultsTable.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/ResultsTable.tsx
@@ -3,6 +3,7 @@ import { type ReactElement, useMemo } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { t, Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { docsTip } from '../../../configuration/shared/utils';
@@ -38,6 +39,12 @@ export function ResultsTable(props: ResultsTableProps) {
 
   function selectMetric(metric: MetricData) {
     if (metric.value) {
+      reportInteraction('grafana_prometheus_metrics_explorer_metric_selected', {
+        hasType: !!metric.type,
+        searchQuery: searchedText,
+        selectedTypesCount: selectedTypes.length,
+        pageNum,
+      });
       onChange({ ...query, metric: metric.value });
       onClose();
     }


### PR DESCRIPTION
## Motivation

This PR fixes #237.

## What this PR does

- Adds `reportInteraction` events for the Query Explorer modal: opened, search performed, type filter changed, page changed, and metric selected.
- Adds `reportInteraction` events for the Metrics Browser (Code mode): metric/label/value search, metric/label-key/label-value clicks, validate, clear, and query applied (use query vs. use as rate query).
- Metrics Explorer tracking existed before it was removed (in https://github.com/grafana/grafana/pull/108437) during a refactor and was never reinstated; Metrics Browser previously only tracked its open/close toggle.
- Label-value search intentionally omits the raw search text from its payload (result counts only), since label values can carry sensitive/high-cardinality data — everything else follows the naming/payload conventions of existing events (e.g. `user_grafana_prometheus_editor_mode_clicked`, `grafana_prom_kickstart_toggle_pattern_card`).