### PR TITLE
fix(prometheus): fetch metrics browser labels on series limit blur

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.test.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { selectors } from '@grafana/e2e-selectors';
+
+import { MetricSelector } from './MetricSelector';
+import { useMetricsBrowser } from './MetricsBrowserContext';
+
+jest.mock('./MetricsBrowserContext', () => ({
+  useMetricsBrowser: jest.fn(),
+}));
+
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    useStyles2: () => ({
+      section: 'section',
+      valueListWrapper: 'valueListWrapper',
+      valueList: 'valueList',
+    }),
+    BrowserLabel: ({ name }: { name: string }) => <div>{name}</div>,
+  };
+});
+
+const seriesLimitTestId = selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit;
+
+describe('MetricSelector series limit input', () => {
+  const setSeriesLimit = jest.fn();
+  const onMetricClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMetricsBrowser as jest.Mock).mockReturnValue({
+      metrics: [{ name: 'up' }],
+      selectedMetric: '',
+      seriesLimit: 40000,
+      setSeriesLimit,
+      onMetricClick,
+    });
+  });
+
+  it('does not call setSeriesLimit while typing (only updates local draft)', async () => {
+    const user = userEvent.setup();
+    render(<MetricSelector />);
+
+    const input = screen.getByTestId(seriesLimitTestId);
+    await user.clear(input);
+    await user.type(input, '5000');
+
+    expect(setSeriesLimit).not.toHaveBeenCalled();
+    expect(input).toHaveValue('5000');
+  });
+
+  it('calls setSeriesLimit on blur with the parsed limit', async () => {
+    const user = userEvent.setup();
+    render(<MetricSelector />);
+
+    const input = screen.getByTestId(seriesLimitTestId);
+    await user.clear(input);
+    await user.type(input, '5000');
+    await user.tab();
+
+    expect(setSeriesLimit).toHaveBeenCalledTimes(1);
+    expect(setSeriesLimit).toHaveBeenCalledWith(5000);
+  });
+
+  it('calls setSeriesLimit when Enter is pressed', async () => {
+    const user = userEvent.setup();
+    render(<MetricSelector />);
+
+    const input = screen.getByTestId(seriesLimitTestId);
+    await user.clear(input);
+    await user.type(input, '1000{Enter}');
+
+    expect(setSeriesLimit).toHaveBeenCalledWith(1000);
+  });
+});

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -14,6 +14,30 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+
+  // Keep a local draft while typing so we only commit the limit (and trigger
+  // label/metric refetch) on blur — not on every keystroke.
+  // See https://github.com/grafana/grafana/issues/120727
+  const [seriesLimitInput, setSeriesLimitInput] = useState(
+    Number.isFinite(seriesLimit) ? String(seriesLimit) : ''
+  );
+
+  useEffect(() => {
+    setSeriesLimitInput(Number.isFinite(seriesLimit) ? String(seriesLimit) : '');
+  }, [seriesLimit]);
+
+  const applySeriesLimit = (rawValue: string) => {
+    const trimmed = rawValue.trim();
+    if (trimmed === '') {
+      // Empty means "use default"; NaN is handled downstream as empty limit.
+      setSeriesLimit(NaN);
+      return;
+    }
+    const parsed = parseInt(trimmed, 10);
+    if (!Number.isNaN(parsed)) {
+      setSeriesLimit(parsed);
+    }
+  };
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +75,19 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setSeriesLimitInput(e.currentTarget.value)}
+            onBlur={(e) => applySeriesLimit(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                applySeriesLimit(e.currentTarget.value);
+                e.currentTarget.blur();
+              }
+            }}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={seriesLimitInput}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>


### PR DESCRIPTION
## What

The metrics browser series limit input called `setSeriesLimit` on every `onChange` keystroke. That updates shared context state and triggers a debounced backend fetch for metrics/labels while the user is still typing.

This change:

- keeps a **local draft** of the input value while typing
- commits the limit via `setSeriesLimit` only on **`onBlur`** (or **Enter**)
- adds unit tests covering the keystroke vs blur behavior

## Why

Fixes [grafana/grafana#120727](https://github.com/grafana/grafana/issues/120727):

> right after the series limit value change the metrics browser makes a new fetch request to the backend. It should do fetching `onBlur` not `onChange`.

Note: the Prometheus metrics browser now lives in this repository (`@grafana/prometheus`), not in the main Grafana monorepo.

## How to test

```bash
yarn workspace @grafana/prometheus test --testPathPattern=MetricSelector.test --watchAll=false
```

Manually:

1. Open Explore with a Prometheus datasource
2. Open the metrics browser
3. Change the series limit digit-by-digit
4. Confirm network fetches do **not** fire until you leave the field (blur) or press Enter

## Related

- Issue: https://github.com/grafana/grafana/issues/120727
- Prior approach of yarn-patching published `dist` files is avoided; this is a source fix in the canonical package.

Fixes grafana/grafana#120727