### PR TITLE
test: Cover resource header framing to catch externalized datasource 500s

### DIFF
--- a/.changeset/tidy-tests-framing.md
+++ b/.changeset/tidy-tests-framing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tests only: add unit, HTTP-boundary and e2e coverage for resource-handler header framing, plus a gzip-forcing dev proxy. No user-facing change.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   # Vanilla upstream Prometheus so the provisioned 'prometheus' datasource
-  # (url: http://prometheus:9090) actually points at a running server. It
-  # scrapes itself and the Grafana dev container, giving real metric names,
-  # label names and label values to exercise the plugin against.
+  # actually points at a running server. It scrapes itself and the Grafana dev
+  # container, giving real metric names, label names and label values to
+  # exercise the plugin against.
   prometheus:
     image: prom/prometheus
     container_name: 'prometheus'
@@ -11,12 +11,34 @@ services:
     ports:
       - 9090:9090/tcp
 
+  # Test-only gzip-forcing reverse proxy in front of Prometheus. The provisioned
+  # datasource points at this (http://prometheus-gzip:9091) instead of directly
+  # at Prometheus so responses are always gzip-compressed with an explicit
+  # Content-Length. That deterministically recreates the framing conditions that
+  # produced the externalized-plugin 500s; vanilla Prometheus does not reliably
+  # emit this shape, which is exactly why the original bug hid from tests.
+  prometheus-gzip:
+    image: golang:1.26-alpine
+    container_name: 'prometheus-gzip'
+    depends_on:
+      - prometheus
+    working_dir: /app
+    volumes:
+      - ./tests/gzip-proxy/main.go:/app/main.go:ro
+    environment:
+      UPSTREAM: http://prometheus:9090
+      LISTEN: ':9091'
+      GOTOOLCHAIN: local
+      GOPROXY: 'off'
+    command: ['go', 'run', 'main.go']
+
   grafana:
     extends:
       file: .config/docker-compose-base.yaml
       service: grafana
     depends_on:
       - prometheus
+      - prometheus-gzip
     environment:
       # Grafana 13 enables splashScreen by default; the overlay blocks Playwright interactions.
       GF_FEATURE_TOGGLES_splashScreen: 'false'

--- a/pkg/promlib/resource/resource_test.go
+++ b/pkg/promlib/resource/resource_test.go
@@ -2,15 +2,18 @@ package resource_test
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
 
+	"github.com/andybalholm/brotli"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	scope "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
@@ -154,6 +157,144 @@ func TestResource_ExecuteStripsEncodingHeadersAfterDecode(t *testing.T) {
 
 	// Unrelated headers must be preserved.
 	require.Equal(t, "application/json", headers.Get("Content-Type"))
+}
+
+// TestResource_ExecuteStripsFramingHeadersAcrossEncodings pins the invariant that
+// motivated the fix: whenever Execute decodes a body, the framing headers that
+// described the *original* payload (Content-Encoding, Content-Length,
+// Transfer-Encoding) must not survive onto the now-plaintext response, while
+// unrelated headers (Content-Type) must. It runs across every encoding Decode
+// understands plus the identity ("") case, so no single codec can regress and the
+// plaintext path can't be over-pruned.
+func TestResource_ExecuteStripsFramingHeadersAcrossEncodings(t *testing.T) {
+	body := []byte(`{"status":"success","data":["job","instance","__name__"]}`)
+
+	testCases := []struct {
+		name     string
+		encoding string
+	}{
+		{name: "gzip", encoding: "gzip"},
+		{name: "deflate", encoding: "deflate"},
+		{name: "brotli", encoding: "br"},
+		{name: "identity", encoding: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := compress(t, tc.encoding, body)
+
+			header := http.Header{
+				"Content-Type":      []string{"application/json"},
+				"Content-Length":    []string{strconv.Itoa(len(payload))},
+				"Transfer-Encoding": []string{"chunked"},
+			}
+			if tc.encoding != "" {
+				header.Set("Content-Encoding", tc.encoding)
+			}
+
+			mockClient := &http.Client{
+				Transport: &mockRoundTripper{
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader(payload)),
+						Header:     header,
+					},
+				},
+			}
+			settings := backend.DataSourceInstanceSettings{
+				ID:       1,
+				URL:      "http://mock-server",
+				JSONData: []byte(`{}`),
+			}
+			res, err := resource.New(mockClient, settings, log.DefaultLogger)
+			require.NoError(t, err)
+
+			resp, err := res.Execute(context.Background(), &backend.CallResourceRequest{URL: "/api/v1/labels"})
+			require.NoError(t, err)
+
+			require.Equal(t, body, resp.Body, "body must be decoded to plaintext")
+
+			h := http.Header(resp.Headers)
+			require.Empty(t, h.Get("Content-Encoding"), "Content-Encoding must be stripped after decode")
+			require.Empty(t, h.Get("Content-Length"), "Content-Length must be stripped after decode")
+			require.Empty(t, h.Get("Transfer-Encoding"), "Transfer-Encoding must be stripped after decode")
+			require.Equal(t, "application/json", h.Get("Content-Type"), "unrelated headers must be preserved")
+		})
+	}
+}
+
+// TestResource_ExecuteResponseSurvivesHTTPBoundary reproduces the production
+// failure mode end-to-end at the HTTP layer, without needing Grafana. The unit
+// tests above assert on the returned struct in memory; this one additionally
+// crosses the serialize -> HTTP write -> read boundary that the externalized
+// plugin's response actually traverses (gRPC -> Grafana proxy -> browser), which
+// is the only place a header/body framing mismatch turns into a real error.
+//
+// The upstream returns a gzip body with an explicit Content-Length for the
+// *compressed* bytes — exactly the shape that produced the HTTP 500. With the
+// stale framing headers relayed (the bug), replaying the CallResourceResponse
+// over a real http.Server truncates to the short Content-Length and/or leaves
+// Content-Encoding: gzip on plaintext, so a real client fails to read it. With
+// the headers stripped, the body round-trips cleanly.
+func TestResource_ExecuteResponseSurvivesHTTPBoundary(t *testing.T) {
+	// A comfortably compressible payload so the gzipped bytes are strictly
+	// smaller than the plaintext; that size gap is what makes a relayed,
+	// too-short Content-Length corrupt the downstream write.
+	labels := make([]string, 0, 200)
+	for i := 0; i < 200; i++ {
+		labels = append(labels, "label_name_"+strconv.Itoa(i))
+	}
+	plaintext, err := json.Marshal(map[string]any{"status": "success", "data": labels})
+	require.NoError(t, err)
+	gzipped := gzipBody(t, plaintext)
+	require.Less(t, len(gzipped), len(plaintext), "sanity: gzipped payload must be smaller than plaintext")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(gzipped)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(gzipped)
+	}))
+	defer upstream.Close()
+
+	settings := backend.DataSourceInstanceSettings{
+		ID:       1,
+		URL:      upstream.URL,
+		JSONData: []byte(`{}`),
+	}
+	// DisableCompression makes the client hand the *compressed* bytes to the
+	// plugin instead of transparently decoding them. This mirrors production,
+	// where utils.Decode (not the transport) owns decompression — the whole
+	// reason the stale-header bug is reachable in the first place.
+	pluginClient := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	res, err := resource.New(pluginClient, settings, log.DefaultLogger)
+	require.NoError(t, err)
+
+	callResp, err := res.Execute(context.Background(), &backend.CallResourceRequest{URL: "/api/v1/labels"})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, callResp.Status)
+
+	// Replay the plugin's response the way Grafana's proxy writes it back out.
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for name, values := range callResp.Headers {
+			for _, v := range values {
+				w.Header().Add(name, v)
+			}
+		}
+		w.WriteHeader(callResp.Status)
+		_, _ = w.Write(callResp.Body)
+	}))
+	defer proxy.Close()
+
+	// Default transport transparently negotiates and decodes gzip, mirroring a browser.
+	httpResp, err := http.Get(proxy.URL) //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = httpResp.Body.Close() }()
+
+	got, err := io.ReadAll(httpResp.Body)
+	require.NoError(t, err, "reading the proxied body must not fail on a framing/decoding mismatch")
+	require.Equal(t, plaintext, got, "body must survive the HTTP boundary intact")
 }
 
 func TestResource_GetSuggestions(t *testing.T) {
@@ -343,11 +484,57 @@ func TestSchemaProvider_ColumnsDecodesCompressedResponses(t *testing.T) {
 	require.Equal(t, "short", resp.TableMetadata["up"].Unit)
 }
 
+// compress encodes body with the given Content-Encoding, mirroring what an
+// upstream Prometheus would send. An empty encoding returns the body unchanged
+// (identity), matching utils.Decode's handling of the "" case.
+func compress(t *testing.T, encoding string, body []byte) []byte {
+	t.Helper()
+
+	switch encoding {
+	case "gzip":
+		return gzipBody(t, body)
+	case "deflate":
+		return deflateBody(t, body)
+	case "br":
+		return brotliBody(t, body)
+	case "":
+		return body
+	default:
+		t.Fatalf("unsupported encoding %q", encoding)
+		return nil
+	}
+}
+
 func gzipBody(t *testing.T, body []byte) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
 	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+func deflateBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+func brotliBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := brotli.NewWriter(&buf)
 	_, err := writer.Write(body)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -1,11 +1,14 @@
 apiVersion: 1
 
 datasources:
+  # Points at the gzip-forcing proxy (see docker-compose.yaml) rather than
+  # Prometheus directly, so resource calls (labels, label values, rules) exercise
+  # the gzip-decode + header-stripping path that regressed in production.
   - name: 'prometheus'
     uid: 'prometheus'
     type: 'prometheus'
     access: proxy
-    url: 'http://prometheus:9090'
+    url: 'http://prometheus-gzip:9091'
     isDefault: false
     orgId: 1
     version: 1

--- a/provisioning/prometheus/prometheus.yml
+++ b/provisioning/prometheus/prometheus.yml
@@ -1,9 +1,13 @@
 # Scrape config for the dev Prometheus. It scrapes itself and the Grafana dev
 # container so there are real metric names, label names and label values to
 # exercise the plugin against.
+# Short intervals so the dev/e2e Prometheus has scraped series within a few
+# seconds of startup. Tests must still not depend on scraped data existing
+# (that is a race regardless of interval), but this keeps manual exploration and
+# any data-bearing checks responsive.
 global:
-  scrape_interval: 60s
-  evaluation_interval: 60s
+  scrape_interval: 5s
+  evaluation_interval: 5s
 
 scrape_configs:
   - job_name: prometheus

--- a/tests/e2e/resourceCalls.spec.ts
+++ b/tests/e2e/resourceCalls.spec.ts
@@ -16,6 +16,12 @@ import { expect, test } from '@grafana/plugin-e2e';
 const DATASOURCE_UID = 'prometheus';
 const resourcePath = (p: string) => `/api/datasources/uid/${DATASOURCE_UID}/resources${p}`;
 
+// Deliberately assert only on the framing/decoding contract (200 + a
+// well-formed, decoded JSON envelope), NOT on the presence of specific labels
+// or metric names. The latter depends on Prometheus having completed at least
+// one scrape, which is a startup race the test must not couple to. If the
+// header-framing bug regresses, the proxy returns a 500 or the body fails to
+// decode into JSON here regardless of whether any series exist yet.
 test.describe('Resource calls (externalized plugin, gzip upstream)', () => {
   test('label names resource call returns 200 with a decoded JSON body', { tag: '@plugins' }, async ({ request }) => {
     const res = await request.get(resourcePath('/api/v1/labels'));
@@ -25,8 +31,6 @@ test.describe('Resource calls (externalized plugin, gzip upstream)', () => {
     const json = await res.json();
     expect(json.status).toBe('success');
     expect(Array.isArray(json.data)).toBe(true);
-    // Prometheus always exposes at least the __name__ label for its own metrics.
-    expect(json.data).toContain('__name__');
   });
 
   test('label values resource call returns 200 with a decoded JSON body', { tag: '@plugins' }, async ({ request }) => {
@@ -37,6 +41,5 @@ test.describe('Resource calls (externalized plugin, gzip upstream)', () => {
     const json = await res.json();
     expect(json.status).toBe('success');
     expect(Array.isArray(json.data)).toBe(true);
-    expect(json.data.length).toBeGreaterThan(0);
   });
 });

--- a/tests/e2e/resourceCalls.spec.ts
+++ b/tests/e2e/resourceCalls.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// These tests exercise the datasource *resource* path (labels, label values,
+// rules) end-to-end through Grafana's externalized-plugin proxy. This is the
+// path that regressed in production: the plugin decoded the gzip body but
+// relayed the upstream's stale Content-Encoding/Content-Length, so the proxy
+// hit a framing mismatch and returned HTTP 500. Queries were unaffected because
+// they never relay raw upstream framing.
+//
+// The provisioned 'prometheus' datasource points at the gzip-forcing proxy (see
+// docker-compose.yaml), so every response here is gzip-compressed with an
+// explicit Content-Length — the exact shape that triggers the bug. A plain
+// smoke test that only checks UI rendering would stay green while this path is
+// broken; asserting a real 200 + decoded JSON body is what catches it.
+
+const DATASOURCE_UID = 'prometheus';
+const resourcePath = (p: string) => `/api/datasources/uid/${DATASOURCE_UID}/resources${p}`;
+
+test.describe('Resource calls (externalized plugin, gzip upstream)', () => {
+  test('label names resource call returns 200 with a decoded JSON body', { tag: '@plugins' }, async ({ request }) => {
+    const res = await request.get(resourcePath('/api/v1/labels'));
+
+    expect(res.status(), 'labels resource call must not 500 on a gzip framing mismatch').toBe(200);
+
+    const json = await res.json();
+    expect(json.status).toBe('success');
+    expect(Array.isArray(json.data)).toBe(true);
+    // Prometheus always exposes at least the __name__ label for its own metrics.
+    expect(json.data).toContain('__name__');
+  });
+
+  test('label values resource call returns 200 with a decoded JSON body', { tag: '@plugins' }, async ({ request }) => {
+    const res = await request.get(resourcePath('/api/v1/label/__name__/values'));
+
+    expect(res.status(), 'label values resource call must not 500 on a gzip framing mismatch').toBe(200);
+
+    const json = await res.json();
+    expect(json.status).toBe('success');
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/gzip-proxy/main.go
+++ b/tests/gzip-proxy/main.go
@@ -1,0 +1,95 @@
+//go:build ignore
+
+// Command gzip-proxy is a test-only reverse proxy that sits in front of an
+// upstream Prometheus and forces every response to be gzip-compressed with an
+// explicit Content-Length for the compressed bytes.
+//
+// This deterministically recreates the production conditions behind the
+// externalized Prometheus datasource 500s: the datasource plugin decodes the
+// gzip body to plaintext but, before the fix, relayed the stale
+// Content-Encoding/Content-Length upstream headers, so the downstream proxy saw
+// a framing mismatch and reset the write with an HTTP 500.
+//
+// Vanilla prom/prometheus does not reliably emit this shape, so relying on it
+// alone lets the bug hide. This proxy removes that non-determinism.
+//
+// Configuration (environment variables):
+//
+//	UPSTREAM - upstream base URL (default "http://prometheus:9090")
+//	LISTEN   - listen address    (default ":9090")
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+)
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	upstream := getenv("UPSTREAM", "http://prometheus:9090")
+	listen := getenv("LISTEN", ":9090")
+
+	target, err := url.Parse(upstream)
+	if err != nil {
+		log.Fatalf("invalid UPSTREAM %q: %v", upstream, err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	orig := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		orig(r)
+		// Force the upstream to answer in plaintext so this proxy fully controls
+		// the gzip framing it sends downstream.
+		r.Header.Del("Accept-Encoding")
+	}
+
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.Header.Get("Content-Encoding") != "" {
+			return nil // already encoded, leave it alone
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			return closeErr
+		}
+
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		if _, err := gz.Write(body); err != nil {
+			return err
+		}
+		if err := gz.Close(); err != nil {
+			return err
+		}
+
+		resp.Body = io.NopCloser(&buf)
+		resp.Header.Set("Content-Encoding", "gzip")
+		// Explicit Content-Length = the *compressed* size. After the plugin
+		// decompresses, it writes the larger plaintext body while this small
+		// length is still declared, which is what triggers the downstream 500
+		// when the stale header is relayed.
+		resp.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+		resp.ContentLength = int64(buf.Len())
+		return nil
+	}
+
+	log.Printf("gzip-proxy listening on %s, forwarding to %s", listen, upstream)
+	log.Fatal(http.ListenAndServe(listen, proxy)) //nolint:gosec
+}


### PR DESCRIPTION
### What & why

We had a bug on ops where externalized Prometheus datasource couldn't get any resources (labels, label values). Queries were fine. Fixed in #232, but the problem is we couldn't catch it on dev or with tests, only real people detected it. This is not good. So this PR adds the missing test coverage for that class of bug.

### Changes

- **Unit (table-driven):** `TestResource_ExecuteStripsFramingHeadersAcrossEncodings` checks that after decode we always strip `Content-Encoding` / `Content-Length` / `Transfer-Encoding` and keep unrelated headers, across gzip / deflate / br / identity.
- **Integration (HTTP boundary):** `TestResource_ExecuteResponseSurvivesHTTPBoundary` replays the `CallResourceResponse` through a real HTTP server + client, which is where the framing mismatch actually turns into an error. Uses `DisableCompression` so the plugin owns the decode like in production (otherwise the transport hides the bug).
- **e2e:** new `resourceCalls.spec.ts` hits the resource path (`/labels`, `/label/__name__/values`) through Grafana's external-plugin proxy and asserts 200 + decoded body, not only UI rendering.
- **gzip proxy:** test-only reverse proxy in front of Prometheus that forces gzip + explicit `Content-Length`, so the exact framing shape is deterministic. Datasource points to it in dev/e2e. Excluded from build via `//go:build ignore`.
