### PR TITLE
ci: add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-arm64-small
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 750
+          # start from the oldest issues/PRs when performing stale operations
+          ascending: true
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          exempt-issue-labels: no stalebot,type/epic
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 30 days. Thank you for your contributions!
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: no stalebot
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            activity in the last 30 days. It will be closed in 2 weeks if no further activity occurs. Please
+            feel free to give a status update or ping for review. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had any further
+            activity in the last 2 weeks. Thank you for your contributions!


### PR DESCRIPTION
Copies the stale workflow from [grafana/grafana](https://github.com/grafana/grafana/blob/main/.github/workflows/stale.yml) verbatim, as part of a rollout across the standalone data source repos.

What it does:

- Issues inactive for 1 year are labelled `stale`, then closed after a further 30 days of inactivity.
- PRs inactive for 30 days are labelled `stale`, then closed after a further 2 weeks.
- Apply the `no stalebot` label to exempt an issue or PR (issues labelled `type/epic` are also exempt).

**User-facing impact:** community issues and PRs in this repo will start receiving stale warnings and may be auto-closed by the bot.
