### PR TITLE
feat: PoC Prometheus/Mimir streaming Search API over HTTP

### DIFF
--- a/.changeset/search-streams-arrive.md
+++ b/.changeset/search-streams-arrive.md
@@ -1,0 +1,6 @@
+---
+'@grafana/prometheus': minor
+'promlib': minor
+---
+
+Add opt-in Prometheus Search API support with streamed metric discovery and fuzzy autocomplete.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ shown to the user. Search streams remain subject to the data source response
 limit; the bounded limits used by discovery consumers keep normal requests
 within that limit.
 
+See the [Search API feature lifecycle](./docs/prometheus-search-api-lifecycle.md)
+for the complete browser-to-Prometheus request and response flow.
+
 ## Issues
 
 Please report bugs and feature requests at

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ no installation is required.
 For detailed setup instructions, see the
 [Prometheus data source documentation](https://grafana.com/docs/grafana/latest/datasources/prometheus/).
 
+### Streaming Search API
+
+The optional **Search API** data source setting uses Prometheus's streaming
+metric and label discovery endpoints. It enables server-ranked fuzzy search in
+the metric picker and code editor, and progressively renders results in the
+Metrics explorer.
+
+The target must be Prometheus v3.13 or later started with
+`--enable-feature=search-api`, or Mimir started with
+`-querier.experimental-search-api-enabled`. Grafana does not fall back to the
+legacy discovery endpoints when this setting is enabled, so upstream errors are
+shown to the user. Search streams remain subject to the data source response
+limit; the bounded limits used by discovery consumers keep normal requests
+within that limit.
+
 ## Issues
 
 Please report bugs and feature requests at

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,17 @@
 services:
-  # Vanilla upstream Prometheus so the provisioned 'prometheus' datasource
-  # (url: http://prometheus:9090) actually points at a running server. It
-  # scrapes itself and the Grafana dev container, giving real metric names,
-  # label names and label values to exercise the plugin against.
+  # --enable-feature=search-api shipped (still experimental/flagged) in the official
+  # Prometheus 3.13.0 release, so the official image now supports it directly — no local
+  # source build needed. Must pin >= v3.13.0 explicitly: the `latest` tag has a known bug
+  # (https://github.com/prometheus/prometheus/issues/18962) where it can resolve to an
+  # older backported-fix release that predates search-api and rejects the flag.
   prometheus:
-    image: prom/prometheus
-    container_name: 'prometheus'
+    image: prom/prometheus:v3.13.1
+    container_name: 'prometheus-search-api'
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --enable-feature=search-api
+      - --web.listen-address=0.0.0.0:9090
+      - --storage.tsdb.path=/tmp/tsdb
     volumes:
       - ./provisioning/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -16,6 +16,7 @@ const dataProviderSettings = {
     queryMetricsMetadata: jest.fn().mockResolvedValue({}),
     retrieveLabelKeys: jest.fn(),
     retrieveMetricsMetadata: jest.fn().mockReturnValue({}),
+    getSearchApiClient: jest.fn().mockReturnValue(undefined),
   },
   historyProvider: history.map((expr, idx) => ({ query: { expr, refId: 'some-ref' }, ts: idx })),
 } as unknown as DataProviderParams;

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -1,5 +1,6 @@
 import { config } from '@grafana/runtime';
 
+import { DEFAULT_COMPLETION_LIMIT } from '../../../constants';
 import { getFunctions } from '../../../promql';
 import { getMockTimeRange } from '../../../test/mocks/datasource';
 
@@ -189,6 +190,26 @@ describe('Label value completions', () => {
       expect(completions[1].insertText).toBe('"value\\"2"');
       expect(completions[2].insertText).toBe('"value\\\\3"');
       expect(completions[3].insertText).toBe('"value\'4"');
+    });
+
+    it('passes the typed term to label value search', async () => {
+      const queryLabelValues = jest.spyOn(dataProvider, 'queryLabelValues').mockResolvedValue(['production']);
+      const situation: Situation = {
+        type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
+        labelName: 'environment',
+        betweenQuotes: true,
+        otherLabels: [],
+      };
+
+      await getCompletions(situation, dataProvider, timeRange, 'prod');
+
+      expect(queryLabelValues).toHaveBeenCalledWith(
+        timeRange,
+        'environment',
+        undefined,
+        DEFAULT_COMPLETION_LIMIT,
+        'prod'
+      );
     });
   });
 

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -138,10 +138,11 @@ async function getLabelNames(
   metric: string | undefined,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<string[]> {
   const selector = makeSelector(metric, otherLabels);
-  const labelNames = await dataProvider.queryLabelKeys(timeRange, selector, DEFAULT_COMPLETION_LIMIT);
+  const labelNames = await dataProvider.queryLabelKeys(timeRange, selector, DEFAULT_COMPLETION_LIMIT, searchTerm);
   // Exclude __name__ from output
   otherLabels.push({ name: '__name__', value: '', op: '!=' });
   const usedLabelNames = new Set(otherLabels.map((l) => l.name));
@@ -155,9 +156,10 @@ async function getLabelNamesForCompletions(
   triggerOnInsert: boolean,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<Completion[]> {
-  const labelNames = await getLabelNames(metric, otherLabels, dataProvider, timeRange);
+  const labelNames = await getLabelNames(metric, otherLabels, dataProvider, timeRange, searchTerm);
   return labelNames.map((text) => {
     const isUtf8 = !isValidLegacyName(text);
     return {
@@ -180,18 +182,20 @@ async function getLabelNamesForSelectorCompletions(
   metric: string | undefined,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions(metric, '=', true, otherLabels, dataProvider, timeRange);
+  return getLabelNamesForCompletions(metric, '=', true, otherLabels, dataProvider, timeRange, searchTerm);
 }
 
 async function getLabelNamesForByCompletions(
   metric: string | undefined,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions(metric, '', false, otherLabels, dataProvider, timeRange);
+  return getLabelNamesForCompletions(metric, '', false, otherLabels, dataProvider, timeRange, searchTerm);
 }
 
 async function getLabelValues(
@@ -199,10 +203,11 @@ async function getLabelValues(
   labelName: string,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<string[]> {
   const selector = makeSelector(metric, otherLabels);
-  return await dataProvider.queryLabelValues(timeRange, labelName, selector);
+  return await dataProvider.queryLabelValues(timeRange, labelName, selector, DEFAULT_COMPLETION_LIMIT, searchTerm);
 }
 
 async function getLabelValuesForMetricCompletions(
@@ -211,9 +216,10 @@ async function getLabelValuesForMetricCompletions(
   betweenQuotes: boolean,
   otherLabels: Label[],
   dataProvider: DataProvider,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  searchTerm?: string
 ): Promise<Completion[]> {
-  const values = await getLabelValues(metric, labelName, otherLabels, dataProvider, timeRange);
+  const values = await getLabelValues(metric, labelName, otherLabels, dataProvider, timeRange, searchTerm);
   return values.map((text) => ({
     type: 'LABEL_VALUE',
     label: text,
@@ -254,9 +260,21 @@ export async function getCompletions(
       return Promise.resolve([...historyCompletions, ...getFunctionCompletions(), ...metricNames]);
     }
     case 'IN_LABEL_SELECTOR_NO_LABEL_NAME':
-      return getLabelNamesForSelectorCompletions(situation.metricName, situation.otherLabels, dataProvider, timeRange);
+      return getLabelNamesForSelectorCompletions(
+        situation.metricName,
+        situation.otherLabels,
+        dataProvider,
+        timeRange,
+        searchTerm
+      );
     case 'IN_GROUPING':
-      return getLabelNamesForByCompletions(situation.metricName, situation.otherLabels, dataProvider, timeRange);
+      return getLabelNamesForByCompletions(
+        situation.metricName,
+        situation.otherLabels,
+        dataProvider,
+        timeRange,
+        searchTerm
+      );
     case 'IN_LABEL_SELECTOR_WITH_LABEL_NAME':
       return getLabelValuesForMetricCompletions(
         situation.metricName,
@@ -264,7 +282,8 @@ export async function getCompletions(
         situation.betweenQuotes,
         situation.otherLabels,
         dataProvider,
-        timeRange
+        timeRange,
+        searchTerm
       );
     default:
       throw new NeverCaseError(situation);

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
@@ -12,6 +12,7 @@ const createLanguageProviderMock = (existingMetadata: Record<string, unknown> = 
   queryMetricsMetadata: jest.fn().mockResolvedValue({}),
   retrieveMetrics: jest.fn().mockReturnValue([]),
   retrieveMetricsMetadata: jest.fn().mockReturnValue(existingMetadata),
+  getSearchApiClient: jest.fn().mockReturnValue(undefined),
 });
 
 const createDataProvider = (
@@ -112,6 +113,54 @@ describe('DataProvider', () => {
       const result = await dataProvider.queryMetricNames(timeRange, undefined);
 
       expect(result).toEqual([]);
+    });
+
+    it('uses fuzzy search and aborts the superseded metric request', async () => {
+      const languageProvider = createLanguageProviderMock();
+      const searchMetricNames = jest
+        .fn()
+        .mockResolvedValue({ results: [{ name: 'http_requests_total' }], warnings: [], hasMore: false });
+      languageProvider.getSearchApiClient.mockReturnValue({ searchMetricNames });
+      const dataProvider = createDataProvider(languageProvider);
+
+      await expect(dataProvider.queryMetricNames(timeRange, 'http req')).resolves.toEqual(['http_requests_total']);
+      const firstSignal = searchMetricNames.mock.calls[0][2].signal as AbortSignal;
+      await dataProvider.queryMetricNames(timeRange, 'http requ');
+
+      expect(searchMetricNames).toHaveBeenLastCalledWith(
+        timeRange,
+        'http requ',
+        expect.objectContaining({ limit: DEFAULT_COMPLETION_LIMIT, signal: expect.any(AbortSignal) })
+      );
+      expect(firstSignal.aborted).toBe(true);
+      expect(languageProvider.queryLabelValues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fuzzy label search', () => {
+    it('searches label values using the typed term', async () => {
+      const languageProvider = createLanguageProviderMock();
+      const searchLabelValues = jest
+        .fn()
+        .mockResolvedValue({ results: [{ value: 'production' }], warnings: [], hasMore: false });
+      languageProvider.getSearchApiClient.mockReturnValue({ searchLabelValues });
+      const dataProvider = createDataProvider(languageProvider);
+
+      await expect(
+        dataProvider.queryLabelValues(timeRange, 'environment', '{job="api"}', DEFAULT_COMPLETION_LIMIT, 'prod')
+      ).resolves.toEqual(['production']);
+
+      expect(searchLabelValues).toHaveBeenCalledWith(
+        timeRange,
+        'environment',
+        'prod',
+        expect.objectContaining({
+          match: '{job="api"}',
+          limit: DEFAULT_COMPLETION_LIMIT,
+          signal: expect.any(AbortSignal),
+        })
+      );
+      expect(languageProvider.queryLabelValues).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -22,15 +22,13 @@ export class DataProvider {
   readonly languageProvider: PrometheusLanguageProviderInterface;
   readonly historyProvider: Array<HistoryItem<PromQuery>>;
 
-  readonly queryLabelKeys: typeof this.languageProvider.queryLabelKeys;
-  readonly queryLabelValues: typeof this.languageProvider.queryLabelValues;
+  private metricSearchAbortController?: AbortController;
+  private labelKeySearchAbortController?: AbortController;
+  private labelValueSearchAbortController?: AbortController;
 
   constructor(params: DataProviderParams) {
     this.languageProvider = params.languageProvider;
     this.historyProvider = params.historyProvider;
-
-    this.queryLabelKeys = this.languageProvider.queryLabelKeys.bind(this.languageProvider);
-    this.queryLabelValues = this.languageProvider.queryLabelValues.bind(this.languageProvider);
 
     // Ensure metadata is loaded for completions. The builder mode triggers this via its own
     // components, but the code editor does not, so we need to fetch it here if not already cached.
@@ -46,6 +44,17 @@ export class DataProvider {
    */
   queryMetricNames = async (timeRange: TimeRange, searchTerm: string | undefined): Promise<string[]> => {
     try {
+      const searchClient = this.languageProvider.getSearchApiClient?.();
+      if (searchClient) {
+        this.metricSearchAbortController?.abort();
+        this.metricSearchAbortController = new AbortController();
+        const response = await searchClient.searchMetricNames(timeRange, searchTerm ?? '', {
+          limit: DEFAULT_COMPLETION_LIMIT,
+          signal: this.metricSearchAbortController.signal,
+        });
+        return response.results.map((result) => result.name);
+      }
+
       let match: string | undefined;
       if (searchTerm) {
         const escapedWord = escapeForUtf8Support(removeQuotesIfExist(searchTerm));
@@ -64,6 +73,52 @@ export class DataProvider {
       console.warn('Failed to query metric names:', error);
       return [];
     }
+  };
+
+  queryLabelKeys = async (
+    timeRange: TimeRange,
+    match?: string,
+    limit?: number,
+    searchTerm?: string
+  ): Promise<string[]> => {
+    const searchClient = this.languageProvider.getSearchApiClient?.();
+    if (searchClient && searchTerm) {
+      this.labelKeySearchAbortController?.abort();
+      this.labelKeySearchAbortController = new AbortController();
+      const response = await searchClient.searchLabelNames(timeRange, searchTerm, {
+        limit: limit ?? DEFAULT_COMPLETION_LIMIT,
+        match,
+        signal: this.labelKeySearchAbortController.signal,
+      });
+      return response.results.map((result) => result.name);
+    }
+    return this.languageProvider.queryLabelKeys(timeRange, match, limit);
+  };
+
+  queryLabelValues = async (
+    timeRange: TimeRange,
+    labelKey: string,
+    match?: string,
+    limit?: number,
+    searchTerm?: string
+  ): Promise<string[]> => {
+    const searchClient = this.languageProvider.getSearchApiClient?.();
+    if (searchClient && searchTerm) {
+      this.labelValueSearchAbortController?.abort();
+      this.labelValueSearchAbortController = new AbortController();
+      const response = await searchClient.searchLabelValues(
+        timeRange,
+        removeQuotesIfExist(labelKey),
+        removeQuotesIfExist(searchTerm),
+        {
+          limit: limit ?? DEFAULT_COMPLETION_LIMIT,
+          match,
+          signal: this.labelValueSearchAbortController.signal,
+        }
+      );
+      return response.results.map((result) => result.value);
+    }
+    return this.languageProvider.queryLabelValues(timeRange, labelKey, match, limit);
   };
 
   getHistory(): string[] {

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -46,7 +46,7 @@ export class DataProvider {
    */
   queryMetricNames = async (timeRange: TimeRange, searchTerm: string | undefined): Promise<string[]> => {
     try {
-      const searchClient = this.languageProvider.getSearchApiClient?.();
+      const searchClient = this.languageProvider.getSearchApiClient();
       if (searchClient) {
         // Search API ranks the raw editor text server-side; the regex and UTF-8
         // escaping below belong only to the legacy label-values endpoint.
@@ -85,7 +85,7 @@ export class DataProvider {
     limit?: number,
     searchTerm?: string
   ): Promise<string[]> => {
-    const searchClient = this.languageProvider.getSearchApiClient?.();
+    const searchClient = this.languageProvider.getSearchApiClient();
     if (searchClient && searchTerm) {
       // Empty-prefix requests use the drop-in ResourceApiClient path. Typed
       // prefixes use the fuzzy extension so Prometheus can rank matches.
@@ -108,7 +108,7 @@ export class DataProvider {
     limit?: number,
     searchTerm?: string
   ): Promise<string[]> => {
-    const searchClient = this.languageProvider.getSearchApiClient?.();
+    const searchClient = this.languageProvider.getSearchApiClient();
     if (searchClient && searchTerm) {
       this.labelValueSearchAbortController?.abort();
       this.labelValueSearchAbortController = new AbortController();

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -22,6 +22,8 @@ export class DataProvider {
   readonly languageProvider: PrometheusLanguageProviderInterface;
   readonly historyProvider: Array<HistoryItem<PromQuery>>;
 
+  // Completion categories can request concurrently, but a newer request in the
+  // same category always supersedes the previous typed prefix.
   private metricSearchAbortController?: AbortController;
   private labelKeySearchAbortController?: AbortController;
   private labelValueSearchAbortController?: AbortController;
@@ -46,6 +48,8 @@ export class DataProvider {
     try {
       const searchClient = this.languageProvider.getSearchApiClient?.();
       if (searchClient) {
+        // Search API ranks the raw editor text server-side; the regex and UTF-8
+        // escaping below belong only to the legacy label-values endpoint.
         this.metricSearchAbortController?.abort();
         this.metricSearchAbortController = new AbortController();
         const response = await searchClient.searchMetricNames(timeRange, searchTerm ?? '', {
@@ -83,6 +87,8 @@ export class DataProvider {
   ): Promise<string[]> => {
     const searchClient = this.languageProvider.getSearchApiClient?.();
     if (searchClient && searchTerm) {
+      // Empty-prefix requests use the drop-in ResourceApiClient path. Typed
+      // prefixes use the fuzzy extension so Prometheus can rank matches.
       this.labelKeySearchAbortController?.abort();
       this.labelKeySearchAbortController = new AbortController();
       const response = await searchClient.searchLabelNames(timeRange, searchTerm, {

--- a/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
@@ -71,6 +71,13 @@ describe('PromSettings', () => {
       expect(screen.getByText('Use series endpoint')).toBeInTheDocument();
     });
 
+    it('should have a search API configuration element', () => {
+      const options = defaultProps;
+
+      render(<PromSettings onOptionsChange={() => {}} options={options} />);
+      expect(screen.getByText('Search API')).toBeInTheDocument();
+    });
+
     it('should hide query samples processed threshold fields by default', () => {
       const options = defaultProps;
 

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -769,6 +769,24 @@ export const PromSettings = (props: Props) => {
                 onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
               />
             </InlineField>
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              label={t('grafana-prometheus.configuration.prom-settings.label-search-api', 'Search API')}
+              tooltip={
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-search-api">
+                  Use the streaming Search API for metric and label discovery. Requires Prometheus with
+                  --enable-feature=search-api or Mimir with -querier.experimental-search-api-enabled.
+                </Trans>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+              className={styles.switchField}
+            >
+              <Switch
+                value={optionsWithDefaults.jsonData.searchApi ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'searchApi')}
+              />
+            </InlineField>
           </Stack>
         </Box>
       </ConfigSubSection>

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -783,8 +783,8 @@ export const PromSettings = (props: Props) => {
               className={styles.switchField}
             >
               <Switch
-                value={optionsWithDefaults.jsonData.searchApi ?? false}
-                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'searchApi')}
+                value={optionsWithDefaults.jsonData.enableSearchApi ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'enableSearchApi')}
               />
             </InlineField>
           </Stack>

--- a/packages/grafana-prometheus/src/constants.ts
+++ b/packages/grafana-prometheus/src/constants.ts
@@ -20,6 +20,12 @@ export const DEFAULT_SERIES_LIMIT = 40000;
 
 export const DEFAULT_COMPLETION_LIMIT = 1000;
 
+// Default results per NDJSON batch line for every Search API request. Smaller
+// values let incremental consumers (e.g. Metrics Explorer) paint the first rows
+// sooner, at the cost of more updates. It only affects streaming granularity,
+// never the final result set. Matches Prometheus's own default of 100.
+export const SEARCH_STREAM_BATCH_SIZE = 100;
+
 /**
  * Only for /series endpoint. Don't use this anywhere else as it cause an expensive query
  */

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -92,6 +92,7 @@ export class PrometheusDatasource
   languageProvider: PrometheusLanguageProviderInterface;
   lookupsDisabled: boolean;
   ruleMappings: RuleQueryMapping;
+  searchApi: boolean;
   seriesEndpoint: boolean;
   seriesLimit: number;
   type: string;
@@ -126,6 +127,7 @@ export class PrometheusDatasource
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup ?? false;
     this.ruleMappings = {};
+    this.searchApi = instanceSettings.jsonData.searchApi ?? false;
     this.seriesEndpoint = instanceSettings.jsonData.seriesEndpoint ?? false;
     this.seriesLimit = instanceSettings.jsonData.seriesLimit ?? DEFAULT_SERIES_LIMIT;
     this.type = 'prometheus';
@@ -237,6 +239,10 @@ export class PrometheusDatasource
       //https://github.com/thanos-io/thanos/releases/tag/v0.18.0
       this._isDatasourceVersionGreaterOrEqualTo('0.18.0', PromApplication.Thanos)
     );
+  }
+
+  hasSearchApiSupport(): boolean {
+    return this.searchApi;
   }
 
   _isDatasourceVersionGreaterOrEqualTo(targetVersion: string, targetFlavor: PromApplication): boolean {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -92,7 +92,7 @@ export class PrometheusDatasource
   languageProvider: PrometheusLanguageProviderInterface;
   lookupsDisabled: boolean;
   ruleMappings: RuleQueryMapping;
-  searchApi: boolean;
+  enableSearchApi: boolean;
   seriesEndpoint: boolean;
   seriesLimit: number;
   type: string;
@@ -127,7 +127,7 @@ export class PrometheusDatasource
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup ?? false;
     this.ruleMappings = {};
-    this.searchApi = instanceSettings.jsonData.searchApi ?? false;
+    this.enableSearchApi = instanceSettings.jsonData.enableSearchApi ?? false;
     this.seriesEndpoint = instanceSettings.jsonData.seriesEndpoint ?? false;
     this.seriesLimit = instanceSettings.jsonData.seriesLimit ?? DEFAULT_SERIES_LIMIT;
     this.type = 'prometheus';
@@ -242,7 +242,7 @@ export class PrometheusDatasource
   }
 
   hasSearchApiSupport(): boolean {
-    return this.searchApi;
+    return this.enableSearchApi;
   }
 
   _isDatasourceVersionGreaterOrEqualTo(targetVersion: string, targetFlavor: PromApplication): boolean {

--- a/packages/grafana-prometheus/src/language_provider.mock.ts
+++ b/packages/grafana-prometheus/src/language_provider.mock.ts
@@ -18,4 +18,6 @@ export class EmptyLanguageProviderMock {
     .fn()
     .mockReturnValue({ histogram_metric_sum: { type: 'counter', help: '', unit: 'sum' } });
   queryMetricsMetadata = jest.fn().mockResolvedValue({});
+  hasSearchSupport = jest.fn().mockReturnValue(false);
+  getSearchApiClient = jest.fn().mockReturnValue(undefined);
 }

--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -11,6 +11,8 @@ import {
   PrometheusLanguageProvider,
 } from './language_provider';
 import { getPrometheusTime, getRangeSnapInterval } from './language_utils';
+import { LabelsApiClient, SeriesApiClient } from './resource_clients';
+import { SearchApiClient } from './search_api_client';
 import { PrometheusCacheLevel, type PromQuery } from './types';
 
 jest.mock('./language_utils', () => ({
@@ -62,6 +64,7 @@ describe('PrometheusLanguageProvider', () => {
     getTimeRangeParams: getTimeRangeParams,
     interpolateString: (string: string) => string,
     hasLabelsMatchAPISupport: () => false,
+    hasSearchApiSupport: () => false,
     getDaysToCacheMetadata: () => 1,
     getAdjustedInterval: () => getRangeSnapInterval(PrometheusCacheLevel.None, getMockQuantizedTimeRangeParams()),
     cacheLevel: PrometheusCacheLevel.None,
@@ -73,7 +76,7 @@ describe('PrometheusLanguageProvider', () => {
   describe('constructor', () => {
     it('should initialize with SeriesApiClient when labels match API is not supported', () => {
       const provider = new PrometheusLanguageProvider(defaultDatasource);
-      expect(provider).toBeInstanceOf(PrometheusLanguageProvider);
+      expect(provider['resourceClient']).toBeInstanceOf(SeriesApiClient);
     });
 
     it('should initialize with LabelsApiClient when labels match API is supported', () => {
@@ -82,7 +85,19 @@ describe('PrometheusLanguageProvider', () => {
         hasLabelsMatchAPISupport: () => true,
       } as unknown as PrometheusDatasource;
       const provider = new PrometheusLanguageProvider(datasourceWithLabelsAPI);
-      expect(provider).toBeInstanceOf(PrometheusLanguageProvider);
+      expect(provider['resourceClient']).toBeInstanceOf(LabelsApiClient);
+    });
+
+    it('should prefer SearchApiClient when search API is enabled', () => {
+      const datasourceWithSearchAPI = {
+        ...defaultDatasource,
+        hasSearchApiSupport: () => true,
+      } as unknown as PrometheusDatasource;
+      const provider = new PrometheusLanguageProvider(datasourceWithSearchAPI);
+
+      expect(provider['resourceClient']).toBeInstanceOf(SearchApiClient);
+      expect(provider.hasSearchSupport()).toBe(true);
+      expect(provider.getSearchApiClient()).toBeInstanceOf(SearchApiClient);
     });
   });
 

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -148,6 +148,7 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
    * Lazily initializes and returns the appropriate resource client based on Prometheus version.
    *
    * The client selection logic:
+   * - When explicitly enabled: Uses SearchApiClient for streaming discovery
    * - For Prometheus v2.6+ with labels API: Uses LabelsApiClient for efficient label-based queries
    * - For older versions: Falls back to SeriesApiClient for backward compatibility
    *
@@ -158,6 +159,9 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
   private get resourceClient(): ResourceApiClient {
     if (!this._resourceClient) {
       if (this.datasource.hasSearchApiSupport()) {
+        // The explicit setting wins over automatic version detection. We do
+        // not silently fall back because that would hide a misconfigured
+        // Prometheus/Mimir search feature flag.
         this._resourceClient = new SearchApiClient(this.request, this.datasource);
       } else {
         this._resourceClient = this.datasource.hasLabelsMatchAPISupport()

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -20,6 +20,7 @@ import { extractLabelMatchers, fixSummariesMetadata, toPromLikeQuery } from './l
 import { promqlGrammar } from './promql';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { LabelsApiClient, type ResourceApiClient, SeriesApiClient } from './resource_clients';
+import { SearchApiClient } from './search_api_client';
 import { type PromMetricsMetadata, type PromQuery } from './types';
 
 interface PrometheusBaseLanguageProvider {
@@ -114,6 +115,10 @@ export interface PrometheusLanguageProviderInterface extends PrometheusBaseLangu
    * Use zero (0) to fetch all label values, but this might return huge amounts of data.
    */
   queryLabelValues: (timeRange: TimeRange, labelKey: string, match?: string, limit?: number) => Promise<string[]>;
+
+  hasSearchSupport: () => boolean;
+
+  getSearchApiClient: () => SearchApiClient | undefined;
 }
 
 export class PrometheusLanguageProvider implements PrometheusLanguageProviderInterface {
@@ -152,13 +157,26 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
    */
   private get resourceClient(): ResourceApiClient {
     if (!this._resourceClient) {
-      this._resourceClient = this.datasource.hasLabelsMatchAPISupport()
-        ? new LabelsApiClient(this.request, this.datasource)
-        : new SeriesApiClient(this.request, this.datasource);
+      if (this.datasource.hasSearchApiSupport()) {
+        this._resourceClient = new SearchApiClient(this.request, this.datasource);
+      } else {
+        this._resourceClient = this.datasource.hasLabelsMatchAPISupport()
+          ? new LabelsApiClient(this.request, this.datasource)
+          : new SeriesApiClient(this.request, this.datasource);
+      }
     }
 
     return this._resourceClient;
   }
+
+  public hasSearchSupport = (): boolean => {
+    return this.datasource.hasSearchApiSupport();
+  };
+
+  public getSearchApiClient = (): SearchApiClient | undefined => {
+    const client = this.resourceClient;
+    return client instanceof SearchApiClient ? client : undefined;
+  };
 
   /**
    * Same start logic but it uses resource clients. Backward compatibility it calls _backwardCompatibleStart.

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 
+import { DEFAULT_COMPLETION_LIMIT } from '../../constants';
 import { PrometheusDatasource } from '../../datasource';
 import { type PrometheusLanguageProviderInterface } from '../../language_provider';
 import { EmptyLanguageProviderMock } from '../../language_provider.mock';
@@ -62,6 +63,8 @@ describe('MetricCombobox', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (mockLanguageProvider.hasSearchSupport as jest.Mock).mockReturnValue(false);
+    (mockLanguageProvider.getSearchApiClient as jest.Mock).mockReturnValue(undefined);
   });
 
   it('renders correctly', () => {
@@ -102,6 +105,33 @@ describe('MetricCombobox', () => {
       '__name__',
       '{__name__=~".*unique.*"}'
     );
+  });
+
+  it('uses fuzzy metric search when the search API is enabled', async () => {
+    const searchMetricNames = jest.fn().mockResolvedValue({
+      results: [{ name: 'http_requests_total' }],
+      warnings: [],
+      hasMore: false,
+    });
+    (mockLanguageProvider.hasSearchSupport as jest.Mock).mockReturnValue(true);
+    (mockLanguageProvider.getSearchApiClient as jest.Mock).mockReturnValue({ searchMetricNames });
+
+    render(<MetricCombobox {...defaultProps} />);
+
+    const combobox = screen.getByPlaceholderText('Select metric');
+    await userEvent.click(combobox);
+    await userEvent.type(combobox, 'http req');
+
+    expect(await screen.findByRole('option', { name: 'http_requests_total' })).toBeInTheDocument();
+    expect(searchMetricNames).toHaveBeenCalledWith(
+      defaultProps.timeRange,
+      'http req',
+      expect.objectContaining({
+        limit: DEFAULT_COMPLETION_LIMIT,
+        signal: expect.anything(),
+      })
+    );
+    expect(mockDatasource.languageProvider.queryLabelValues).not.toHaveBeenCalled();
   });
 
   it('calls onChange with the correct value when a metric is selected', async () => {

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { type GrafanaTheme2, type SelectableValue, type TimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -7,7 +7,7 @@ import { Trans, t } from '@grafana/i18n';
 import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
 import { Button, InlineField, InlineFieldRow, Combobox, type ComboboxOption, useTheme2 } from '@grafana/ui';
 
-import { METRIC_LABEL } from '../../constants';
+import { DEFAULT_COMPLETION_LIMIT, METRIC_LABEL } from '../../constants';
 import { type PrometheusDatasource } from '../../datasource';
 import { type QueryBuilderLabelFilter } from '../shared/types';
 import { type PromVisualQuery } from '../types';
@@ -37,6 +37,7 @@ export function MetricCombobox({
   timeRange,
 }: Readonly<MetricComboboxProps>) {
   const [metricsModalOpen, setMetricsModalOpen] = useState(false);
+  const searchAbortControllerRef = useRef<AbortController>();
   const styles = getStyles(useTheme2());
 
   /**
@@ -44,6 +45,23 @@ export function MetricCombobox({
    */
   const getMetricLabels = useCallback(
     async (query: string) => {
+      const searchClient = datasource.languageProvider.getSearchApiClient();
+      if (searchClient) {
+        searchAbortControllerRef.current?.abort();
+        const abortController = new AbortController();
+        searchAbortControllerRef.current = abortController;
+        const match = labelsFilters.length > 0 ? formatKeyValueStrings('', labelsFilters) : undefined;
+        const response = await searchClient.searchMetricNames(timeRange, query, {
+          limit: DEFAULT_COMPLETION_LIMIT,
+          match,
+          signal: abortController.signal,
+        });
+        return response.results.map((result) => ({
+          label: result.name,
+          value: result.name,
+        }));
+      }
+
       const match = formatKeyValueStrings(query, labelsFilters);
       const results = await datasource.languageProvider.queryLabelValues(timeRange, METRIC_LABEL, match);
 
@@ -57,6 +75,8 @@ export function MetricCombobox({
     },
     [datasource.languageProvider, labelsFilters, timeRange]
   );
+
+  useEffect(() => () => searchAbortControllerRef.current?.abort(), []);
 
   const onComboboxChange = useCallback(
     (opt: ComboboxOption<string> | null) => {

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -47,6 +47,8 @@ export function MetricCombobox({
     async (query: string) => {
       const searchClient = datasource.languageProvider.getSearchApiClient();
       if (searchClient) {
+        // The search endpoint ranks the user's raw text. Label filters remain a
+        // match[] selector, and cancellation prevents stale options winning.
         searchAbortControllerRef.current?.abort();
         const abortController = new AbortController();
         searchAbortControllerRef.current = abortController;

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.test.tsx
@@ -21,6 +21,8 @@ const mockLanguageProvider: PrometheusLanguageProviderInterface = {
   queryMetricsMetadata: jest.fn(),
   queryLabelValues: jest.fn(),
   retrieveMetricsMetadata: jest.fn(),
+  hasSearchSupport: jest.fn().mockReturnValue(false),
+  getSearchApiClient: jest.fn().mockReturnValue(undefined),
 } as unknown as PrometheusLanguageProviderInterface;
 
 // Helper to create wrapper component
@@ -210,6 +212,54 @@ describe('MetricsModalContext', () => {
   });
 
   describe('Backend search', () => {
+    it('appends streamed search API batches incrementally', async () => {
+      let resolveSearch: (() => void) | undefined;
+      const searchMetricNames = jest.fn().mockImplementation((_timeRange, term, options) => {
+        if (term === '') {
+          return Promise.resolve({ results: [], warnings: [], hasMore: false });
+        }
+
+        options.onBatch([{ name: 'first_metric', type: 'counter', help: 'First metric' }]);
+        return new Promise((resolve) => {
+          resolveSearch = () => {
+            options.onBatch([{ name: 'second_metric', type: 'gauge', help: 'Second metric' }]);
+            resolve({ results: [], warnings: [], hasMore: false });
+          };
+        });
+      });
+      const searchLanguageProvider = {
+        ...mockLanguageProvider,
+        hasSearchSupport: jest.fn().mockReturnValue(true),
+        getSearchApiClient: jest.fn().mockReturnValue({ searchMetricNames }),
+      } as unknown as PrometheusLanguageProviderInterface;
+      const { result } = renderHook(() => useMetricsModal(), {
+        wrapper: createWrapper(searchLanguageProvider),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      let pendingSearch: Promise<void>;
+      act(() => {
+        pendingSearch = result.current.debouncedBackendSearch(defaultTimeRange, 'metric');
+      });
+
+      await waitFor(() => {
+        expect(result.current.filteredMetricsData).toEqual([
+          { value: 'first_metric', type: 'counter', description: 'First metric' },
+        ]);
+      });
+
+      await act(async () => {
+        resolveSearch?.();
+        await pendingSearch;
+      });
+
+      expect(result.current.filteredMetricsData).toEqual([
+        { value: 'first_metric', type: 'counter', description: 'First metric' },
+        { value: 'second_metric', type: 'gauge', description: 'Second metric' },
+      ]);
+      expect(mockLanguageProvider.queryLabelValues).not.toHaveBeenCalled();
+    });
+
     it('should perform backend search with results', async () => {
       (mockLanguageProvider.queryLabelValues as jest.Mock).mockResolvedValue(['test_metric', 'other_metric']);
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -15,6 +15,7 @@ import { type SelectableValue, type TimeRange } from '@grafana/data';
 
 import { METRIC_LABEL, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
+import { type SearchMetricResult } from '../../../search_api_client';
 import { regexifyLabelValuesQueryString } from '../../parsingUtils';
 import { type QueryBuilderLabelFilter } from '../../shared/types';
 import { formatPrometheusLabelFilters } from '../formatter';
@@ -69,6 +70,8 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
   });
   const [selectedTypes, setSelectedTypes] = useState<Array<SelectableValue<string>>>([]);
   const [searchedText, setSearchedText] = useState('');
+  const latestSearchIdRef = useRef<number>(0);
+  const searchAbortControllerRef = useRef<AbortController>();
 
   const filteredMetricsData = useMemo(() => {
     if (selectedTypes.length === 0) {
@@ -105,34 +108,91 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
     }));
   }, [filteredMetricsData.length, pagination.resultsPerPage, pagination.pageNum]);
 
-  // Track the latest search ID to handle race conditions
-  const latestSearchIdRef = useRef<number>(0);
+  const toMetricData = useCallback(
+    (result: SearchMetricResult): MetricData => ({
+      value: result.name,
+      type: result.type,
+      description: result.help,
+    }),
+    []
+  );
 
-  const fetchMetadata = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const metadata = await languageProvider.queryMetricsMetadata(PROMETHEUS_QUERY_BUILDER_MAX_RESULTS);
-
-      // We receive ALERTS metadata in any case
-      if (Object.keys(metadata).length <= 1) {
-        const fetchedMetrics = await languageProvider.queryLabelValues(
-          timeRange,
-          METRIC_LABEL,
-          undefined,
-          PROMETHEUS_QUERY_BUILDER_MAX_RESULTS
-        );
-        const processedData = fetchedMetrics.map((m) => generateMetricData(m, languageProvider));
-        setMetricsData(processedData);
-      } else {
-        const processedData = Object.keys(metadata).map((m) => generateMetricData(m, languageProvider));
-        setMetricsData(processedData);
+  const streamSearch = useCallback(
+    async (
+      searchId: number,
+      searchTimeRange: TimeRange,
+      metricText: string,
+      queryLabels?: QueryBuilderLabelFilter[]
+    ): Promise<boolean> => {
+      const searchClient = languageProvider.getSearchApiClient();
+      if (!searchClient) {
+        return false;
       }
-    } catch (error) {
+
+      searchAbortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      searchAbortControllerRef.current = abortController;
+      const filterArray = queryLabels ? formatPrometheusLabelFilters(queryLabels) : [];
+      const match = filterArray.length > 0 ? `{__name__=~".*"${filterArray.join('')}}` : undefined;
+
+      setIsLoading(true);
       setMetricsData([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [languageProvider, timeRange]);
+      await searchClient.searchMetricNames(searchTimeRange, metricText, {
+        includeMetadata: true,
+        limit: PROMETHEUS_QUERY_BUILDER_MAX_RESULTS,
+        match,
+        signal: abortController.signal,
+        onBatch: (batch) => {
+          if (searchId === latestSearchIdRef.current) {
+            setMetricsData((current) => [...current, ...batch.map(toMetricData)]);
+          }
+        },
+      });
+
+      if (searchId === latestSearchIdRef.current) {
+        setIsLoading(false);
+      }
+      return true;
+    },
+    [languageProvider, toMetricData]
+  );
+
+  const fetchMetadata = useCallback(
+    async (searchId = ++latestSearchIdRef.current) => {
+      try {
+        setIsLoading(true);
+        if (await streamSearch(searchId, timeRange, '')) {
+          return;
+        }
+
+        const metadata = await languageProvider.queryMetricsMetadata(PROMETHEUS_QUERY_BUILDER_MAX_RESULTS);
+
+        // We receive ALERTS metadata in any case
+        if (Object.keys(metadata).length <= 1) {
+          const fetchedMetrics = await languageProvider.queryLabelValues(
+            timeRange,
+            METRIC_LABEL,
+            undefined,
+            PROMETHEUS_QUERY_BUILDER_MAX_RESULTS
+          );
+          const processedData = fetchedMetrics.map((m) => generateMetricData(m, languageProvider));
+          setMetricsData(processedData);
+        } else {
+          const processedData = Object.keys(metadata).map((m) => generateMetricData(m, languageProvider));
+          setMetricsData(processedData);
+        }
+      } catch (error) {
+        if (!languageProvider.hasSearchSupport()) {
+          setMetricsData([]);
+        }
+      } finally {
+        if (searchId === latestSearchIdRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [languageProvider, streamSearch, timeRange]
+  );
 
   const debouncedBackendSearch = useMemo(
     () =>
@@ -142,7 +202,11 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
 
         try {
           if (metricText === '') {
-            await fetchMetadata();
+            await fetchMetadata(searchId);
+            return;
+          }
+
+          if (await streamSearch(searchId, timeRange, metricText, queryLabels)) {
             return;
           }
 
@@ -168,19 +232,21 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
             console.error('Backend search failed:', error);
-            setMetricsData([]); // Clear results on error
+            if (!languageProvider.hasSearchSupport()) {
+              setMetricsData([]);
+            }
             setIsLoading(false);
           }
         }
       }, 300),
-    [fetchMetadata, languageProvider]
+    [fetchMetadata, languageProvider, streamSearch]
   );
 
   useEffect(() => {
     fetchMetadata();
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    return () => searchAbortControllerRef.current?.abort();
+  }, [fetchMetadata]);
 
   return (
     <MetricsModalContext.Provider

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -129,6 +129,9 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
         return false;
       }
 
+      // Abort saves work across browser → Grafana → plugin → Prometheus. The
+      // search ID remains necessary because an already queued batch callback
+      // can run after cancellation.
       searchAbortControllerRef.current?.abort();
       const abortController = new AbortController();
       searchAbortControllerRef.current = abortController;
@@ -138,6 +141,8 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
       setIsLoading(true);
       setMetricsData([]);
       await searchClient.searchMetricNames(searchTimeRange, metricText, {
+        // Search API metadata lets each batch render without waiting for the
+        // separate /metadata request used by the legacy path below.
         includeMetadata: true,
         limit: PROMETHEUS_QUERY_BUILDER_MAX_RESULTS,
         match,
@@ -182,6 +187,8 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
           setMetricsData(processedData);
         }
       } catch (error) {
+        // Search batches may already be visible when a mid-stream error occurs.
+        // Preserve those partial results; the legacy path has no partial data.
         if (!languageProvider.hasSearchSupport()) {
           setMetricsData([]);
         }
@@ -232,6 +239,7 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
             console.error('Backend search failed:', error);
+            // Keep batches already rendered by the streaming path.
             if (!languageProvider.hasSearchSupport()) {
               setMetricsData([]);
             }

--- a/packages/grafana-prometheus/src/resource_clients.ts
+++ b/packages/grafana-prometheus/src/resource_clients.ts
@@ -263,7 +263,7 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
   };
 }
 
-class ResourceClientsCache {
+export class ResourceClientsCache {
   private readonly MAX_CACHE_ENTRIES = 1000; // Maximum number of cache entries
   private readonly MAX_CACHE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB max cache size
 

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -53,13 +53,13 @@ describe('readSearchStream', () => {
     });
   });
 
-  it('treats abrupt EOF as partial success', async () => {
+  it('flags a truncated stream (missing trailer) as incomplete', async () => {
     const response = streamResponse(['{"results":[{"name":"up"}]}\n{"status":"succ']);
 
     await expect(readSearchStream<SearchMetricResult>(response)).resolves.toEqual({
       results: [{ name: 'up' }],
-      warnings: [],
-      hasMore: false,
+      warnings: ['Search stream ended before completion; results may be incomplete.'],
+      hasMore: true,
     });
   });
 

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -1,0 +1,173 @@
+import { dateTime, type TimeRange } from '@grafana/data';
+
+import { type PrometheusDatasource } from './datasource';
+import { readSearchStream, SearchApiClient, type SearchMetricResult } from './search_api_client';
+import { PrometheusCacheLevel } from './types';
+
+const timeRange: TimeRange = {
+  from: dateTime(1681300292392),
+  to: dateTime(1681300293392),
+  raw: { from: 'now-1s', to: 'now' },
+};
+
+const datasource = {
+  uid: 'prometheus/primary',
+  cacheLevel: PrometheusCacheLevel.Low,
+  seriesLimit: 40000,
+  getAdjustedInterval: jest.fn().mockReturnValue({ start: '1681300260', end: '1681300320' }),
+  getTimeRangeParams: jest.fn().mockReturnValue({ start: '1681300260', end: '1681300320' }),
+  interpolateString: jest.fn((value: string) => value),
+} as unknown as PrometheusDatasource;
+
+describe('readSearchStream', () => {
+  it('reads multiple batches and the success trailer', async () => {
+    const onBatch = jest.fn();
+    const response = streamResponse([
+      '{"results":[{"name":"http_requests_total"}]}\n{"res',
+      'ults":[{"name":"http_request_duration_seconds"}],"warnings":["partial"]}\n',
+      '{"status":"success","has_more":true}\n',
+    ]);
+
+    const result = await readSearchStream<SearchMetricResult>(response, onBatch);
+
+    expect(result).toEqual({
+      results: [{ name: 'http_requests_total' }, { name: 'http_request_duration_seconds' }],
+      warnings: ['partial'],
+      hasMore: true,
+    });
+    expect(onBatch).toHaveBeenNthCalledWith(1, [{ name: 'http_requests_total' }]);
+    expect(onBatch).toHaveBeenNthCalledWith(2, [{ name: 'http_request_duration_seconds' }]);
+  });
+
+  it('surfaces mid-stream errors with partial results', async () => {
+    const response = streamResponse([
+      '{"results":[{"name":"up"}]}\n',
+      '{"status":"error","errorType":"internal","error":"search failed"}\n',
+    ]);
+
+    await expect(readSearchStream<SearchMetricResult>(response)).rejects.toMatchObject({
+      message: 'search failed',
+      errorType: 'internal',
+      partialResults: [{ name: 'up' }],
+    });
+  });
+
+  it('treats abrupt EOF as partial success', async () => {
+    const response = streamResponse(['{"results":[{"name":"up"}]}\n{"status":"succ']);
+
+    await expect(readSearchStream<SearchMetricResult>(response)).resolves.toEqual({
+      results: [{ name: 'up' }],
+      warnings: [],
+      hasMore: false,
+    });
+  });
+
+  it('throws the upstream message for non-success responses', async () => {
+    const response = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({
+        status: 'error',
+        errorType: 'unavailable',
+        error: 'search API disabled',
+      }),
+    } as Response;
+
+    await expect(readSearchStream(response)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'search API disabled',
+        errorType: 'unavailable',
+        partialResults: [],
+      })
+    );
+  });
+});
+
+describe('SearchApiClient', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('searches metric names with metadata and score ordering', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        streamResponse([
+          '{"results":[{"name":"http_requests_total","score":0.9,"type":"counter","help":"Requests"}]}\n',
+          '{"status":"success","has_more":false}\n',
+        ])
+      );
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    const result = await client.searchMetricNames(timeRange, 'http req', {
+      limit: 100,
+      includeMetadata: true,
+    });
+
+    expect(result.results).toEqual([{ name: 'http_requests_total', score: 0.9, type: 'counter', help: 'Requests' }]);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/datasources/uid/prometheus%2Fprimary/resources/api/v1/search/metric_names?' +
+        'start=1681300260&end=1681300320&limit=100&search%5B%5D=http+req&sort_by=score&include_metadata=true',
+      {
+        method: 'GET',
+        credentials: 'same-origin',
+        signal: undefined,
+      }
+    );
+  });
+
+  it('adapts metric search results to the resource client interface', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        streamResponse([
+          '{"results":[{"name":"request_duration_bucket"},{"name":"up"}]}\n',
+          '{"status":"success","has_more":false}\n',
+        ])
+      );
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await expect(client.queryMetrics(timeRange, 20)).resolves.toEqual({
+      metrics: ['request_duration_bucket', 'up'],
+      histogramMetrics: ['request_duration_bucket'],
+    });
+  });
+
+  it('passes abort signals to fetch', async () => {
+    globalThis.fetch = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    });
+    const client = new SearchApiClient(jest.fn(), datasource);
+    const controller = new AbortController();
+
+    const promise = client.searchLabelNames(timeRange, 'inst', { signal: controller.signal });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow('aborted');
+  });
+});
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  let index = 0;
+  const body = {
+    getReader: () => ({
+      read: async () =>
+        index < chunks.length
+          ? { done: false, value: encoder.encode(chunks[index++]) }
+          : { done: true, value: undefined },
+    }),
+  };
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: body as ReadableStream<Uint8Array>,
+  } as Response;
+}

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -1,6 +1,7 @@
 import { dateTime, type TimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
+import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { type PrometheusDatasource } from './datasource';
 import { readSearchStream, SearchApiClient, type SearchMetricResult } from './search_api_client';
 import { PrometheusCacheLevel } from './types';
@@ -113,7 +114,7 @@ describe('SearchApiClient', () => {
     expect(result.results).toEqual([{ name: 'http_requests_total', score: 0.9, type: 'counter', help: 'Requests' }]);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       '/api/datasources/uid/prometheus%2Fprimary/resources/api/v1/search/metric_names?' +
-        'start=1681300260&end=1681300320&limit=100&search%5B%5D=http+req&sort_by=score&include_metadata=true',
+        'start=1681300260&end=1681300320&limit=100&search%5B%5D=http+req&sort_by=score&batch_size=100&include_metadata=true',
       {
         method: 'GET',
         credentials: 'same-origin',
@@ -180,6 +181,31 @@ describe('SearchApiClient', () => {
     controller.abort();
 
     await expect(promise).rejects.toThrow('aborted');
+  });
+
+  it('sends batch_size when a batch size is provided', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchMetricNames(timeRange, 'up', { limit: 100, batchSize: 25 });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('batch_size=25'), expect.anything());
+  });
+
+  it('defaults batch_size to the streaming batch size when none is provided', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchMetricNames(timeRange, 'up', { limit: 100 });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`batch_size=${SEARCH_STREAM_BATCH_SIZE}`),
+      expect.anything()
+    );
   });
 });
 

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -104,9 +104,10 @@ describe('readSearchStream', () => {
 describe('SearchApiClient', () => {
   const originalBackendSrv = getBackendSrv();
   const chunkedMock = jest.fn();
+  const getMock = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
-    setBackendSrv({ ...originalBackendSrv, chunked: chunkedMock });
+    setBackendSrv({ ...originalBackendSrv, chunked: chunkedMock, get: getMock });
   });
 
   afterEach(() => {
@@ -217,6 +218,29 @@ describe('SearchApiClient', () => {
       message: 'search API disabled',
       errorType: 'unavailable',
     });
+  });
+
+  it('retries once after a 401, via a login ping, and returns the retried result', async () => {
+    chunkedMock
+      .mockReturnValueOnce(chunkedStream([], { ok: false, status: 401, statusText: 'Unauthorized' }))
+      .mockReturnValueOnce(chunkedStream(['{"results":[{"name":"up"}]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    const result = await client.searchMetricNames(timeRange, 'up', { limit: 10 });
+
+    expect(result.results).toEqual([{ name: 'up' }]);
+    expect(getMock).toHaveBeenCalledWith('/api/login/ping');
+    expect(chunkedMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the error when a 401 persists after the retry', async () => {
+    chunkedMock.mockReturnValue(chunkedStream([], { ok: false, status: 401, statusText: 'Unauthorized' }));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await expect(client.searchMetricNames(timeRange, 'up', { limit: 10 })).rejects.toMatchObject({
+      message: 'Unauthorized',
+    });
+    expect(chunkedMock).toHaveBeenCalledTimes(2);
   });
 
   it('propagates abort by unsubscribing the chunked request', async () => {

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -1,5 +1,7 @@
+import { Observable } from 'rxjs';
+
 import { dateTime, type TimeRange } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { type BackendSrvRequest, type FetchResponse, getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
 import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { type PrometheusDatasource } from './datasource';
@@ -100,23 +102,26 @@ describe('readSearchStream', () => {
 });
 
 describe('SearchApiClient', () => {
-  const originalFetch = globalThis.fetch;
+  const originalBackendSrv = getBackendSrv();
+  const chunkedMock = jest.fn();
+
+  beforeEach(() => {
+    setBackendSrv({ ...originalBackendSrv, chunked: chunkedMock });
+  });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    setBackendSrv(originalBackendSrv);
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
   it('searches metric names with metadata and score ordering', async () => {
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(
-        streamResponse([
-          '{"results":[{"name":"http_requests_total","score":0.9,"type":"counter","help":"Requests"}]}\n',
-          '{"status":"success","has_more":false}\n',
-        ])
-      );
+    chunkedMock.mockReturnValue(
+      chunkedStream([
+        '{"results":[{"name":"http_requests_total","score":0.9,"type":"counter","help":"Requests"}]}\n',
+        '{"status":"success","has_more":false}\n',
+      ])
+    );
     const client = new SearchApiClient(jest.fn(), datasource);
 
     const result = await client.searchMetricNames(timeRange, 'http req', {
@@ -125,26 +130,28 @@ describe('SearchApiClient', () => {
     });
 
     expect(result.results).toEqual([{ name: 'http_requests_total', score: 0.9, type: 'counter', help: 'Requests' }]);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      '/api/datasources/uid/prometheus%2Fprimary/resources/api/v1/search/metric_names?' +
-        'start=1681300260&end=1681300320&limit=100&search%5B%5D=http+req&sort_by=score&batch_size=100&include_metadata=true',
-      {
-        method: 'GET',
-        credentials: 'same-origin',
-        signal: undefined,
-      }
-    );
+    expect(chunkedMock).toHaveBeenCalledWith({
+      url: 'api/datasources/uid/prometheus%2Fprimary/resources/api/v1/search/metric_names',
+      method: 'GET',
+      params: {
+        start: '1681300260',
+        end: '1681300320',
+        limit: '100',
+        'search[]': 'http req',
+        sort_by: 'score',
+        batch_size: '100',
+        include_metadata: 'true',
+      },
+    });
   });
 
   it('adapts metric search results to the resource client interface', async () => {
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(
-        streamResponse([
-          '{"results":[{"name":"request_duration_bucket"},{"name":"up"}]}\n',
-          '{"status":"success","has_more":false}\n',
-        ])
-      );
+    chunkedMock.mockReturnValue(
+      chunkedStream([
+        '{"results":[{"name":"request_duration_bucket"},{"name":"up"}]}\n',
+        '{"status":"success","has_more":false}\n',
+      ])
+    );
     const client = new SearchApiClient(jest.fn(), datasource);
 
     await expect(client.queryMetrics(timeRange, 20)).resolves.toEqual({
@@ -153,71 +160,79 @@ describe('SearchApiClient', () => {
     });
   });
 
-  it('uses the Grafana application subpath', async () => {
-    jest.replaceProperty(config, 'appSubUrl', '/grafana');
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+  it('omits the leading slash so the request resolves under a Grafana subpath install', async () => {
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
     const client = new SearchApiClient(jest.fn(), datasource);
 
     await client.searchMetricNames(timeRange, 'up', { limit: 10 });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringMatching(
-        /^\/grafana\/api\/datasources\/uid\/prometheus%2Fprimary\/resources\/api\/v1\/search\/metric_names\?/
-      ),
-      expect.anything()
-    );
+    expect(chunkedMock).toHaveBeenCalledWith(expect.objectContaining({ url: expect.not.stringMatching(/^\//) }));
   });
 
   it('caps legacy unlimited and default limits at the Prometheus search maximum', async () => {
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":true}\n']));
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":true}\n']));
     const client = new SearchApiClient(jest.fn(), datasource);
 
     await client.searchLabelNames(timeRange, '', { limit: 0 });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('limit=10000'), expect.anything());
+    expect(chunkedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ limit: '10000' }) })
+    );
   });
 
-  it('passes abort signals to fetch', async () => {
-    globalThis.fetch = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
-      return new Promise((_resolve, reject) => {
-        init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
-      });
+  it('surfaces a SearchApiError when the chunked response is not ok', async () => {
+    chunkedMock.mockReturnValue(
+      chunkedStream(['{"status":"error","errorType":"unavailable","error":"search API disabled"}'], {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+    );
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await expect(client.searchMetricNames(timeRange, 'up', { limit: 10 })).rejects.toMatchObject({
+      message: 'search API disabled',
+      errorType: 'unavailable',
     });
+  });
+
+  it('propagates abort by unsubscribing the chunked request', async () => {
+    const unsubscribe = jest.fn();
+    chunkedMock.mockReturnValue(
+      new Observable<FetchResponse<Uint8Array | undefined>>(() => {
+        // Never emits; simulates a long-running request that only ends via unsubscribe.
+        return unsubscribe;
+      })
+    );
     const client = new SearchApiClient(jest.fn(), datasource);
     const controller = new AbortController();
 
     const promise = client.searchLabelNames(timeRange, 'inst', { signal: controller.signal });
     controller.abort();
 
-    await expect(promise).rejects.toThrow('aborted');
+    await expect(promise).rejects.toThrow(/aborted/i);
+    expect(unsubscribe).toHaveBeenCalled();
   });
 
   it('sends batch_size when a batch size is provided', async () => {
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
     const client = new SearchApiClient(jest.fn(), datasource);
 
     await client.searchMetricNames(timeRange, 'up', { limit: 100, batchSize: 25 });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('batch_size=25'), expect.anything());
+    expect(chunkedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ batch_size: '25' }) })
+    );
   });
 
   it('defaults batch_size to the streaming batch size when none is provided', async () => {
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
     const client = new SearchApiClient(jest.fn(), datasource);
 
     await client.searchMetricNames(timeRange, 'up', { limit: 100 });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining(`batch_size=${SEARCH_STREAM_BATCH_SIZE}`),
-      expect.anything()
+    expect(chunkedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ batch_size: String(SEARCH_STREAM_BATCH_SIZE) }) })
     );
   });
 });
@@ -243,21 +258,30 @@ function chunkSource(
   };
 }
 
-function streamResponse(chunks: string[]): Response {
+// Builds a fake getBackendSrv().chunked() Observable that mirrors the real
+// contract: one next() per chunk (each carrying the invariant ok/status
+// fields), a final next() with `data: undefined`, then complete().
+function chunkedStream(
+  chunks: string[],
+  opts: { ok?: boolean; status?: number; statusText?: string } = {}
+): Observable<FetchResponse<Uint8Array | undefined>> {
   const encoder = new TextEncoder();
-  let index = 0;
-  const body = {
-    getReader: () => ({
-      read: async () =>
-        index < chunks.length
-          ? { done: false, value: encoder.encode(chunks[index++]) }
-          : { done: true, value: undefined },
-    }),
-  };
-  return {
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    body: body as ReadableStream<Uint8Array>,
-  } as Response;
+  const { ok = true, status = 200, statusText = 'OK' } = opts;
+  return new Observable<FetchResponse<Uint8Array | undefined>>((subscriber) => {
+    const base = {
+      ok,
+      status,
+      statusText,
+      headers: new Headers(),
+      url: '',
+      type: 'basic' as ResponseType,
+      redirected: false,
+      config: {} as BackendSrvRequest,
+    };
+    for (const chunk of chunks) {
+      subscriber.next({ ...base, data: encoder.encode(chunk) });
+    }
+    subscriber.next({ ...base, data: undefined });
+    subscriber.complete();
+  });
 }

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -243,6 +243,21 @@ describe('SearchApiClient', () => {
     expect(chunkedMock).toHaveBeenCalledTimes(2);
   });
 
+  it('flags a chunked stream that ends without the success trailer as incomplete', async () => {
+    // The trailer line is dropped entirely (not just truncated) to simulate a
+    // connection that ends right after the last data batch.
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[{"name":"up"}]}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    const result = await client.searchMetricNames(timeRange, 'up', { limit: 10 });
+
+    expect(result).toEqual({
+      results: [{ name: 'up' }],
+      warnings: ['Search stream ended before completion; results may be incomplete.'],
+      hasMore: true,
+    });
+  });
+
   it('propagates abort by unsubscribing the chunked request', async () => {
     const unsubscribe = jest.fn();
     chunkedMock.mockReturnValue(

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -1,4 +1,5 @@
 import { dateTime, type TimeRange } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { type PrometheusDatasource } from './datasource';
 import { readSearchStream, SearchApiClient, type SearchMetricResult } from './search_api_client';
@@ -89,6 +90,7 @@ describe('SearchApiClient', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -135,6 +137,34 @@ describe('SearchApiClient', () => {
       metrics: ['request_duration_bucket', 'up'],
       histogramMetrics: ['request_duration_bucket'],
     });
+  });
+
+  it('uses the Grafana application subpath', async () => {
+    jest.replaceProperty(config, 'appSubUrl', '/grafana');
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchMetricNames(timeRange, 'up', { limit: 10 });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\/grafana\/api\/datasources\/uid\/prometheus%2Fprimary\/resources\/api\/v1\/search\/metric_names\?/
+      ),
+      expect.anything()
+    );
+  });
+
+  it('caps legacy unlimited and default limits at the Prometheus search maximum', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(streamResponse(['{"results":[]}\n', '{"status":"success","has_more":true}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchLabelNames(timeRange, '', { limit: 0 });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('limit=10000'), expect.anything());
   });
 
   it('passes abort signals to fetch', async () => {

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -3,7 +3,12 @@ import { config } from '@grafana/runtime';
 
 import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { type PrometheusDatasource } from './datasource';
-import { readSearchStream, SearchApiClient, type SearchMetricResult } from './search_api_client';
+import {
+  readSearchStream,
+  type SearchChunkSource,
+  SearchApiClient,
+  type SearchMetricResult,
+} from './search_api_client';
 import { PrometheusCacheLevel } from './types';
 
 const timeRange: TimeRange = {
@@ -24,13 +29,13 @@ const datasource = {
 describe('readSearchStream', () => {
   it('reads multiple batches and the success trailer', async () => {
     const onBatch = jest.fn();
-    const response = streamResponse([
+    const source = chunkSource([
       '{"results":[{"name":"http_requests_total"}]}\n{"res',
       'ults":[{"name":"http_request_duration_seconds"}],"warnings":["partial"]}\n',
       '{"status":"success","has_more":true}\n',
     ]);
 
-    const result = await readSearchStream<SearchMetricResult>(response, onBatch);
+    const result = await readSearchStream<SearchMetricResult>(source, onBatch);
 
     expect(result).toEqual({
       results: [{ name: 'http_requests_total' }, { name: 'http_request_duration_seconds' }],
@@ -42,12 +47,12 @@ describe('readSearchStream', () => {
   });
 
   it('surfaces mid-stream errors with partial results', async () => {
-    const response = streamResponse([
+    const source = chunkSource([
       '{"results":[{"name":"up"}]}\n',
       '{"status":"error","errorType":"internal","error":"search failed"}\n',
     ]);
 
-    await expect(readSearchStream<SearchMetricResult>(response)).rejects.toMatchObject({
+    await expect(readSearchStream<SearchMetricResult>(source)).rejects.toMatchObject({
       message: 'search failed',
       errorType: 'internal',
       partialResults: [{ name: 'up' }],
@@ -55,9 +60,9 @@ describe('readSearchStream', () => {
   });
 
   it('flags a truncated stream (missing trailer) as incomplete', async () => {
-    const response = streamResponse(['{"results":[{"name":"up"}]}\n{"status":"succ']);
+    const source = chunkSource(['{"results":[{"name":"up"}]}\n{"status":"succ']);
 
-    await expect(readSearchStream<SearchMetricResult>(response)).resolves.toEqual({
+    await expect(readSearchStream<SearchMetricResult>(source)).resolves.toEqual({
       results: [{ name: 'up' }],
       warnings: ['Search stream ended before completion; results may be incomplete.'],
       hasMore: true,
@@ -67,15 +72,13 @@ describe('readSearchStream', () => {
   it('rejects a stream line that exceeds the maximum length', async () => {
     // A single unterminated line larger than the cap must fail fast instead of
     // buffering without bound.
-    const response = streamResponse(['{"results":[' + 'x'.repeat(100)]);
+    const source = chunkSource(['{"results":[' + 'x'.repeat(100)]);
 
-    await expect(readSearchStream<SearchMetricResult>(response, undefined, 16)).rejects.toThrow(
-      /exceeded the maximum/i
-    );
+    await expect(readSearchStream<SearchMetricResult>(source, undefined, 16)).rejects.toThrow(/exceeded the maximum/i);
   });
 
   it('throws the upstream message for non-success responses', async () => {
-    const response = {
+    const source = chunkSource([], {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
@@ -84,9 +87,9 @@ describe('readSearchStream', () => {
         errorType: 'unavailable',
         error: 'search API disabled',
       }),
-    } as Response;
+    });
 
-    await expect(readSearchStream(response)).rejects.toEqual(
+    await expect(readSearchStream(source)).rejects.toEqual(
       expect.objectContaining({
         message: 'search API disabled',
         errorType: 'unavailable',
@@ -218,6 +221,27 @@ describe('SearchApiClient', () => {
     );
   });
 });
+
+// Builds a fake SearchChunkSource that yields the given NDJSON fragments one
+// read() at a time, mirroring how a real chunked transport delivers bytes.
+function chunkSource(
+  chunks: string[],
+  opts: { ok?: boolean; status?: number; statusText?: string; json?: () => Promise<unknown> } = {}
+): SearchChunkSource {
+  const encoder = new TextEncoder();
+  let index = 0;
+  const { ok = true, status = 200, statusText = 'OK', json = async () => ({}) } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    read: async () =>
+      index < chunks.length
+        ? { done: false, value: encoder.encode(chunks[index++]) }
+        : { done: true, value: undefined },
+    json,
+  };
+}
 
 function streamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -64,6 +64,16 @@ describe('readSearchStream', () => {
     });
   });
 
+  it('rejects a stream line that exceeds the maximum length', async () => {
+    // A single unterminated line larger than the cap must fail fast instead of
+    // buffering without bound.
+    const response = streamResponse(['{"results":[' + 'x'.repeat(100)]);
+
+    await expect(readSearchStream<SearchMetricResult>(response, undefined, 16)).rejects.toThrow(
+      /exceeded the maximum/i
+    );
+  });
+
   it('throws the upstream message for non-success responses', async () => {
     const response = {
       ok: false,

--- a/packages/grafana-prometheus/src/search_api_client.test.ts
+++ b/packages/grafana-prometheus/src/search_api_client.test.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 
 import { dateTime, type TimeRange } from '@grafana/data';
-import { type BackendSrvRequest, type FetchResponse, getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { type BackendSrvRequest, config, type FetchResponse, getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
 import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { type PrometheusDatasource } from './datasource';
@@ -142,6 +142,7 @@ describe('SearchApiClient', () => {
         batch_size: '100',
         include_metadata: 'true',
       },
+      headers: {},
     });
   });
 
@@ -167,6 +168,28 @@ describe('SearchApiClient', () => {
     await client.searchMetricNames(timeRange, 'up', { limit: 10 });
 
     expect(chunkedMock).toHaveBeenCalledWith(expect.objectContaining({ url: expect.not.stringMatching(/^\//) }));
+  });
+
+  it('sends X-Grafana-Org-Id when the current org is known', async () => {
+    jest.replaceProperty(config, 'bootData', { ...config.bootData, user: { ...config.bootData.user, orgId: 7 } });
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchMetricNames(timeRange, 'up', { limit: 10 });
+
+    expect(chunkedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: expect.objectContaining({ 'X-Grafana-Org-Id': '7' }) })
+    );
+  });
+
+  it('omits X-Grafana-Org-Id when the current org is unknown', async () => {
+    jest.replaceProperty(config, 'bootData', { ...config.bootData, user: { ...config.bootData.user, orgId: 0 } });
+    chunkedMock.mockReturnValue(chunkedStream(['{"results":[]}\n', '{"status":"success","has_more":false}\n']));
+    const client = new SearchApiClient(jest.fn(), datasource);
+
+    await client.searchMetricNames(timeRange, 'up', { limit: 10 });
+
+    expect(chunkedMock).toHaveBeenCalledWith(expect.objectContaining({ headers: {} }));
   });
 
   it('caps legacy unlimited and default limits at the Prometheus search maximum', async () => {

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -1,5 +1,5 @@
 import { type TimeRange } from '@grafana/data';
-import { type BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
+import { type BackendSrvRequest, config, getBackendSrv } from '@grafana/runtime';
 
 import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
@@ -465,7 +465,16 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     // <base href>, which already accounts for a Grafana subpath install.
     const url = `api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}`;
 
-    const { source, cancel } = await bridgeChunkedResponse({ url, method: 'GET', params }, options.signal);
+    const headers: Record<string, string> = {};
+    // chunked() skips the core pipeline step that normally injects this on
+    // every local-URL request, so a user who switches org without a full
+    // page reload would otherwise query the wrong org's datasource.
+    const orgId = config.bootData?.user?.orgId;
+    if (orgId) {
+      headers['X-Grafana-Org-Id'] = String(orgId);
+    }
+
+    const { source, cancel } = await bridgeChunkedResponse({ url, method: 'GET', params, headers }, options.signal);
     try {
       return await readSearchStream<T>(source, options.onBatch);
     } finally {

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -332,6 +332,21 @@ export async function readSearchStream<T>(
 
 // This client preserves ResourceApiClient's string-array contract for existing
 // consumers and exposes structured streaming methods to search-aware UIs.
+//
+// Transport parity with getBackendSrv().fetch(): search() uses
+// getBackendSrv().chunked() (public @grafana/runtime API) instead of fetch()
+// so streaming NDJSON survives while still gaining credentials handling,
+// param/URL parsing, abort wiring, grafana-trace-id capture, X-Grafana-Org-Id,
+// and a 401-triggered auth-refresh retry (see bridgeChunkedResponse and the
+// `search` method below). A few core BackendSrv behaviors live in private
+// instance state that a plugin cannot reach and are knowingly NOT replicated:
+//   - X-Grafana-Device-Id (FingerprintJS-derived, private `deviceID` field).
+//   - The 5-concurrent-request FetchQueue throttle (private `fetchQueue`).
+//   - Query Inspector stream events (private `inspectorStream`, write-only).
+//   - JWT URL-login header (needs app-internal `loadUrlToken()`).
+//   - showErrorAlert toasts on failure (discovery failures stay silent by design).
+// All are low-impact for background GET discovery, since none of them affect
+// correctness of the search results themselves.
 export class SearchApiClient extends BaseResourceClient implements ResourceApiClient {
   private _cache: ResourceClientsCache = new ResourceClientsCache(this.datasource.cacheLevel);
 

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -98,6 +98,7 @@ export async function readSearchStream<T>(
   const results: T[] = [];
   const warnings: string[] = [];
   let hasMore = false;
+  let sawTrailer = false;
   let buffer = '';
 
   const processLine = (line: string, tolerateIncomplete: boolean) => {
@@ -121,6 +122,7 @@ export async function readSearchStream<T>(
       if (parsed.status === 'error') {
         throw new SearchApiError(parsed.error || 'Search API request failed', results.slice(), parsed.errorType);
       }
+      sawTrailer = true;
       hasMore = parsed.has_more;
       if (parsed.warnings) {
         warnings.push(...parsed.warnings);
@@ -155,6 +157,14 @@ export async function readSearchStream<T>(
     for (const line of lines) {
       processLine(line, false);
     }
+  }
+
+  // A stream that never delivered the success trailer was cut short (a dropped
+  // connection is indistinguishable from a clean EOF at the byte level), so
+  // callers must not treat the partial results as the complete set.
+  if (!sawTrailer) {
+    hasMore = true;
+    warnings.push('Search stream ended before completion; results may be incomplete.');
   }
 
   return { results, warnings, hasMore };
@@ -212,7 +222,9 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     // Unlike the legacy /label/{name}/values endpoint, Search API carries the
     // label name in a query parameter and therefore expects the unescaped name.
     const labelName = removeQuotesIfExist(interpolatedName);
-    const effectiveMatch = `${match ?? ''}-${labelName}`;
+    // Encode the cache key as JSON so a label name or match containing the
+    // delimiter cannot collide with a different (labelName, match) pair.
+    const effectiveMatch = JSON.stringify(['label_values', labelName, match ?? '']);
     const cached = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
     if (cached) {
       return cached.slice();

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -1,6 +1,7 @@
 import { type TimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
+import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
 import { BaseResourceClient, type ResourceApiClient, ResourceClientsCache } from './resource_clients';
 
@@ -35,6 +36,10 @@ export interface SearchOptions<T> {
   match?: string;
   signal?: AbortSignal;
   onBatch?: (results: T[]) => void;
+  // Number of results per NDJSON batch line. This only affects streaming
+  // granularity (time-to-first-batch and how often onBatch fires), not the
+  // accumulated result. Omit to use the upstream default.
+  batchSize?: number;
 }
 
 export interface SearchMetricOptions extends SearchOptions<SearchMetricResult> {
@@ -286,6 +291,13 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     }
     if (options.match) {
       params.append('match[]', options.match);
+    }
+    // batch_size only affects streaming granularity, not the result set, so it
+    // is applied to every Search API request. A single constant therefore tunes
+    // delivery for all consumers; callers may still override it per request.
+    const batchSize = options.batchSize ?? SEARCH_STREAM_BATCH_SIZE;
+    if (batchSize > 0) {
+      params.set('batch_size', String(batchSize));
     }
     for (const [key, value] of Object.entries(extraParams)) {
       if (value !== undefined) {

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -1,7 +1,10 @@
 import { type TimeRange } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
 import { BaseResourceClient, type ResourceApiClient, ResourceClientsCache } from './resource_clients';
+
+const DEFAULT_SEARCH_API_MAX_LIMIT = 10_000;
 
 export interface SearchMetricResult {
   name: string;
@@ -166,7 +169,7 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     timeRange: TimeRange,
     limit?: number
   ): Promise<{ metrics: string[]; histogramMetrics: string[] }> => {
-    const effectiveLimit = this.getEffectiveLimit(limit);
+    const effectiveLimit = this.getEffectiveSearchLimit(limit);
     const response = await this.searchMetricNames(timeRange, '', { limit: effectiveLimit });
     this.metrics = response.results.map((result) => result.name);
     this.histogramMetrics = processHistogramMetrics(this.metrics);
@@ -175,7 +178,7 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
   };
 
   public queryLabelKeys = async (timeRange: TimeRange, match?: string, limit?: number): Promise<string[]> => {
-    const effectiveLimit = this.getEffectiveLimit(limit);
+    const effectiveLimit = this.getEffectiveSearchLimit(limit);
     const effectiveMatch = match ?? '';
     const cached = this._cache.getLabelKeys(timeRange, effectiveMatch, effectiveLimit);
     if (cached) {
@@ -194,7 +197,7 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     match?: string,
     limit?: number
   ): Promise<string[]> => {
-    const effectiveLimit = this.getEffectiveLimit(limit);
+    const effectiveLimit = this.getEffectiveSearchLimit(limit);
     const interpolatedName = this.datasource.interpolateString(labelKey);
     const labelName = removeQuotesIfExist(interpolatedName);
     const effectiveMatch = `${match ?? ''}-${labelName}`;
@@ -250,7 +253,7 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     const params = new URLSearchParams({
       start: String(timeParams.start),
       end: String(timeParams.end),
-      limit: String(this.getEffectiveLimit(options.limit)),
+      limit: String(this.getEffectiveSearchLimit(options.limit)),
     });
 
     if (term) {
@@ -267,8 +270,9 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
     }
 
     const uid = encodeURIComponent(this.datasource.uid);
+    const appSubUrl = config.appSubUrl?.replace(/\/$/, '') ?? '';
     const response = await fetch(
-      `/api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}?${params.toString()}`,
+      `${appSubUrl}/api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}?${params.toString()}`,
       {
         method: 'GET',
         credentials: 'same-origin',
@@ -276,5 +280,13 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
       }
     );
     return readSearchStream<T>(response, options.onBatch);
+  }
+
+  private getEffectiveSearchLimit(limit?: number): number {
+    const effectiveLimit = this.getEffectiveLimit(limit);
+    if (effectiveLimit <= 0) {
+      return DEFAULT_SEARCH_API_MAX_LIMIT;
+    }
+    return Math.min(effectiveLimit, DEFAULT_SEARCH_API_MAX_LIMIT);
   }
 }

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -2,7 +2,6 @@ import { type TimeRange } from '@grafana/data';
 
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
 import { BaseResourceClient, type ResourceApiClient, ResourceClientsCache } from './resource_clients';
-import { escapeForUtf8Support } from './utf8_support';
 
 export interface SearchMetricResult {
   name: string;
@@ -197,14 +196,14 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
   ): Promise<string[]> => {
     const effectiveLimit = this.getEffectiveLimit(limit);
     const interpolatedName = this.datasource.interpolateString(labelKey);
-    const escapedName = escapeForUtf8Support(removeQuotesIfExist(interpolatedName));
-    const effectiveMatch = `${match ?? ''}-${escapedName}`;
+    const labelName = removeQuotesIfExist(interpolatedName);
+    const effectiveMatch = `${match ?? ''}-${labelName}`;
     const cached = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
     if (cached) {
       return cached.slice();
     }
 
-    const response = await this.searchLabelValues(timeRange, escapedName, '', { limit: effectiveLimit, match });
+    const response = await this.searchLabelValues(timeRange, labelName, '', { limit: effectiveLimit, match });
     const values = response.results.map((result) => result.value);
     this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, values);
     return values;

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -1,0 +1,281 @@
+import { type TimeRange } from '@grafana/data';
+
+import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
+import { BaseResourceClient, type ResourceApiClient, ResourceClientsCache } from './resource_clients';
+import { escapeForUtf8Support } from './utf8_support';
+
+export interface SearchMetricResult {
+  name: string;
+  score?: number;
+  type?: string;
+  help?: string;
+  unit?: string;
+}
+
+export interface SearchLabelNameResult {
+  name: string;
+  score?: number;
+}
+
+export interface SearchLabelValueResult {
+  value: string;
+  score?: number;
+}
+
+export interface SearchStreamResult<T> {
+  results: T[];
+  warnings: string[];
+  hasMore: boolean;
+}
+
+export interface SearchOptions<T> {
+  limit?: number;
+  match?: string;
+  signal?: AbortSignal;
+  onBatch?: (results: T[]) => void;
+}
+
+export interface SearchMetricOptions extends SearchOptions<SearchMetricResult> {
+  includeMetadata?: boolean;
+}
+
+interface SearchBatch<T> {
+  results: T[];
+  warnings?: string[];
+}
+
+interface SearchTrailer {
+  status: 'success';
+  has_more: boolean;
+  warnings?: string[];
+}
+
+interface SearchErrorLine {
+  status: 'error';
+  errorType?: string;
+  error?: string;
+}
+
+export class SearchApiError<T = unknown> extends Error {
+  constructor(
+    message: string,
+    public readonly partialResults: T[] = [],
+    public readonly errorType?: string
+  ) {
+    super(message);
+    this.name = 'SearchApiError';
+  }
+}
+
+export async function readSearchStream<T>(
+  response: Response,
+  onBatch?: (results: T[]) => void
+): Promise<SearchStreamResult<T>> {
+  if (!response.ok) {
+    let error: SearchErrorLine | undefined;
+    try {
+      error = (await response.json()) as SearchErrorLine;
+    } catch {
+      // The status text is the best available error when an upstream proxy returns a non-JSON body.
+    }
+    throw new SearchApiError(
+      error?.error || response.statusText || `Search API request failed (${response.status})`,
+      [],
+      error?.errorType
+    );
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return { results: [], warnings: [], hasMore: false };
+  }
+
+  const decoder = new TextDecoder();
+  const results: T[] = [];
+  const warnings: string[] = [];
+  let hasMore = false;
+  let buffer = '';
+
+  const processLine = (line: string, tolerateIncomplete: boolean) => {
+    if (!line.trim()) {
+      return;
+    }
+
+    let parsed: SearchBatch<T> | SearchTrailer | SearchErrorLine;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      if (tolerateIncomplete) {
+        return;
+      }
+      throw error;
+    }
+
+    if ('status' in parsed) {
+      if (parsed.status === 'error') {
+        throw new SearchApiError(parsed.error || 'Search API request failed', results.slice(), parsed.errorType);
+      }
+      hasMore = parsed.has_more;
+      if (parsed.warnings) {
+        warnings.push(...parsed.warnings);
+      }
+      return;
+    }
+
+    if (Array.isArray(parsed.results)) {
+      results.push(...parsed.results);
+      if (parsed.warnings) {
+        warnings.push(...parsed.warnings);
+      }
+      onBatch?.(parsed.results);
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      buffer += decoder.decode();
+      processLine(buffer, true);
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      processLine(line, false);
+    }
+  }
+
+  return { results, warnings, hasMore };
+}
+
+export class SearchApiClient extends BaseResourceClient implements ResourceApiClient {
+  private _cache: ResourceClientsCache = new ResourceClientsCache(this.datasource.cacheLevel);
+
+  public histogramMetrics: string[] = [];
+  public metrics: string[] = [];
+  public labelKeys: string[] = [];
+  public cachedLabelValues: Record<string, string[]> = {};
+
+  public start = async (timeRange: TimeRange) => {
+    await this.queryMetrics(timeRange);
+    this.labelKeys = await this.queryLabelKeys(timeRange);
+  };
+
+  public queryMetrics = async (
+    timeRange: TimeRange,
+    limit?: number
+  ): Promise<{ metrics: string[]; histogramMetrics: string[] }> => {
+    const effectiveLimit = this.getEffectiveLimit(limit);
+    const response = await this.searchMetricNames(timeRange, '', { limit: effectiveLimit });
+    this.metrics = response.results.map((result) => result.name);
+    this.histogramMetrics = processHistogramMetrics(this.metrics);
+    this._cache.setLabelValues(timeRange, undefined, effectiveLimit, this.metrics);
+    return { metrics: this.metrics, histogramMetrics: this.histogramMetrics };
+  };
+
+  public queryLabelKeys = async (timeRange: TimeRange, match?: string, limit?: number): Promise<string[]> => {
+    const effectiveLimit = this.getEffectiveLimit(limit);
+    const effectiveMatch = match ?? '';
+    const cached = this._cache.getLabelKeys(timeRange, effectiveMatch, effectiveLimit);
+    if (cached) {
+      return cached.slice();
+    }
+
+    const response = await this.searchLabelNames(timeRange, '', { limit: effectiveLimit, match });
+    this.labelKeys = response.results.map((result) => result.name);
+    this._cache.setLabelKeys(timeRange, effectiveMatch, effectiveLimit, this.labelKeys);
+    return this.labelKeys.slice();
+  };
+
+  public queryLabelValues = async (
+    timeRange: TimeRange,
+    labelKey: string,
+    match?: string,
+    limit?: number
+  ): Promise<string[]> => {
+    const effectiveLimit = this.getEffectiveLimit(limit);
+    const interpolatedName = this.datasource.interpolateString(labelKey);
+    const escapedName = escapeForUtf8Support(removeQuotesIfExist(interpolatedName));
+    const effectiveMatch = `${match ?? ''}-${escapedName}`;
+    const cached = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
+    if (cached) {
+      return cached.slice();
+    }
+
+    const response = await this.searchLabelValues(timeRange, escapedName, '', { limit: effectiveLimit, match });
+    const values = response.results.map((result) => result.value);
+    this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, values);
+    return values;
+  };
+
+  public searchMetricNames = (
+    timeRange: TimeRange,
+    term: string,
+    options: SearchMetricOptions = {}
+  ): Promise<SearchStreamResult<SearchMetricResult>> => {
+    return this.search('metric_names', timeRange, term, options, {
+      include_metadata: options.includeMetadata ? 'true' : undefined,
+    });
+  };
+
+  public searchLabelNames = (
+    timeRange: TimeRange,
+    term: string,
+    options: SearchOptions<SearchLabelNameResult> = {}
+  ): Promise<SearchStreamResult<SearchLabelNameResult>> => {
+    return this.search('label_names', timeRange, term, options);
+  };
+
+  public searchLabelValues = (
+    timeRange: TimeRange,
+    labelKey: string,
+    term: string,
+    options: SearchOptions<SearchLabelValueResult> = {}
+  ): Promise<SearchStreamResult<SearchLabelValueResult>> => {
+    return this.search('label_values', timeRange, term, options, { label: labelKey });
+  };
+
+  private async search<T>(
+    endpoint: 'metric_names' | 'label_names' | 'label_values',
+    timeRange: TimeRange,
+    term: string,
+    options: SearchOptions<T>,
+    extraParams: Record<string, string | undefined> = {}
+  ): Promise<SearchStreamResult<T>> {
+    const timeParams =
+      endpoint === 'label_names'
+        ? getRangeSnapInterval(this.datasource.cacheLevel, timeRange)
+        : this.datasource.getAdjustedInterval(timeRange);
+    const params = new URLSearchParams({
+      start: String(timeParams.start),
+      end: String(timeParams.end),
+      limit: String(this.getEffectiveLimit(options.limit)),
+    });
+
+    if (term) {
+      params.append('search[]', term);
+      params.set('sort_by', 'score');
+    }
+    if (options.match) {
+      params.append('match[]', options.match);
+    }
+    for (const [key, value] of Object.entries(extraParams)) {
+      if (value !== undefined) {
+        params.set(key, value);
+      }
+    }
+
+    const uid = encodeURIComponent(this.datasource.uid);
+    const response = await fetch(
+      `/api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}?${params.toString()}`,
+      {
+        method: 'GET',
+        credentials: 'same-origin',
+        signal: options.signal,
+      }
+    );
+    return readSearchStream<T>(response, options.onBatch);
+  }
+}

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -82,28 +82,47 @@ export class SearchApiError<T = unknown> extends Error {
   }
 }
 
+// Abstracts over the transport that feeds readSearchStream so both a real
+// Response.body reader (native fetch) and a getBackendSrv().chunked()
+// Observable (bridged into this shape) can drive the same NDJSON parser.
+export interface SearchChunkSource {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  json(): Promise<unknown>;
+}
+
+// Native fetch adapter. Kept only for the interim transport; the streaming
+// getBackendSrv().chunked() bridge is the real production source.
+export function chunkSourceFromResponse(response: Response): SearchChunkSource {
+  const reader = response.body?.getReader();
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    read: () => (reader ? reader.read() : Promise.resolve({ done: true, value: undefined })),
+    json: () => response.json(),
+  };
+}
+
 export async function readSearchStream<T>(
-  response: Response,
+  source: SearchChunkSource,
   onBatch?: (results: T[]) => void,
   maxLineLength: number = MAX_SEARCH_STREAM_LINE_LENGTH
 ): Promise<SearchStreamResult<T>> {
-  if (!response.ok) {
+  if (!source.ok) {
     let error: SearchErrorLine | undefined;
     try {
-      error = (await response.json()) as SearchErrorLine;
+      error = (await source.json()) as SearchErrorLine;
     } catch {
       // The status text is the best available error when an upstream proxy returns a non-JSON body.
     }
     throw new SearchApiError(
-      error?.error || response.statusText || `Search API request failed (${response.status})`,
+      error?.error || source.statusText || `Search API request failed (${source.status})`,
       [],
       error?.errorType
     );
-  }
-
-  const reader = response.body?.getReader();
-  if (!reader) {
-    return { results: [], warnings: [], hasMore: false };
   }
 
   const decoder = new TextDecoder();
@@ -156,7 +175,7 @@ export async function readSearchStream<T>(
   // HTTP chunk boundaries are unrelated to NDJSON line boundaries, so retain
   // the final fragment and prepend it to the next decoded chunk.
   while (true) {
-    const { done, value } = await reader.read();
+    const { done, value } = await source.read();
     if (done) {
       buffer += decoder.decode();
       processLine(buffer, true);
@@ -332,7 +351,7 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
         signal: options.signal,
       }
     );
-    return readSearchStream<T>(response, options.onBatch);
+    return readSearchStream<T>(chunkSourceFromResponse(response), options.onBatch);
   }
 
   private getEffectiveSearchLimit(limit?: number): number {

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -1,5 +1,5 @@
 import { type TimeRange } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { type BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
 
 import { SEARCH_STREAM_BATCH_SIZE } from './constants';
 import { getRangeSnapInterval, processHistogramMetrics, removeQuotesIfExist } from './language_utils';
@@ -93,17 +93,139 @@ export interface SearchChunkSource {
   json(): Promise<unknown>;
 }
 
-// Native fetch adapter. Kept only for the interim transport; the streaming
-// getBackendSrv().chunked() bridge is the real production source.
-export function chunkSourceFromResponse(response: Response): SearchChunkSource {
-  const reader = response.body?.getReader();
-  return {
-    ok: response.ok,
-    status: response.status,
-    statusText: response.statusText,
-    read: () => (reader ? reader.read() : Promise.resolve({ done: true, value: undefined })),
-    json: () => response.json(),
+interface QueuedChunk {
+  done: boolean;
+  value?: Uint8Array;
+}
+
+// getBackendSrv().chunked() is push-based (an Observable that calls next()
+// once per reader.read() result, mirroring `{ done, value }`, with a final
+// next({ data: undefined }) before complete()). readSearchStream is
+// pull-based. This bridges the two without buffering the whole body: each
+// read() call either drains an already-arrived chunk or waits for the next
+// one to be pushed in. Consumers only ever have one read() in flight, so a
+// single pending waiter is enough (no queue of readers needed).
+function bridgeChunkedResponse(
+  request: BackendSrvRequest,
+  signal?: AbortSignal
+): Promise<{ source: SearchChunkSource; cancel: () => void }> {
+  const queue: QueuedChunk[] = [];
+  let waiting: { resolve: (chunk: QueuedChunk) => void; reject: (err: unknown) => void } | undefined;
+  let terminalError: unknown;
+  let hasTerminalError = false;
+
+  const read = (): Promise<QueuedChunk> => {
+    if (queue.length > 0) {
+      return Promise.resolve(queue.shift()!);
+    }
+    if (hasTerminalError) {
+      hasTerminalError = false;
+      return Promise.reject(terminalError);
+    }
+    return new Promise<QueuedChunk>((resolve, reject) => {
+      waiting = { resolve, reject };
+    });
   };
+
+  // The error branch of readSearchStream needs the fully assembled body, so
+  // this drains the (typically small) error payload through the same read()
+  // path rather than requiring a separate buffered accessor on the source.
+  const json = async (): Promise<unknown> => {
+    const decoder = new TextDecoder();
+    let text = '';
+    while (true) {
+      const chunk = await read();
+      if (chunk.value) {
+        text += decoder.decode(chunk.value, { stream: true });
+      }
+      if (chunk.done) {
+        break;
+      }
+    }
+    return JSON.parse(text + decoder.decode());
+  };
+
+  const deliver = (chunk: QueuedChunk) => {
+    if (waiting) {
+      const pending = waiting;
+      waiting = undefined;
+      pending.resolve(chunk);
+    } else {
+      queue.push(chunk);
+    }
+  };
+
+  const fail = (err: unknown) => {
+    if (waiting) {
+      const pending = waiting;
+      waiting = undefined;
+      pending.reject(err);
+    } else {
+      terminalError = err;
+      hasTerminalError = true;
+    }
+  };
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const subscription = getBackendSrv()
+      .chunked(request)
+      .subscribe({
+        next: (response) => {
+          if (!settled) {
+            settled = true;
+            resolve({
+              source: { ok: response.ok, status: response.status, statusText: response.statusText, read, json },
+              cancel: () => subscription.unsubscribe(),
+            });
+          }
+          deliver({ done: response.data === undefined, value: response.data });
+        },
+        error: (err) => {
+          if (!settled) {
+            settled = true;
+            reject(err);
+            return;
+          }
+          fail(err);
+        },
+        complete: () => {
+          if (!settled) {
+            settled = true;
+            resolve({
+              source: { ok: true, status: 200, statusText: 'OK', read, json },
+              cancel: () => subscription.unsubscribe(),
+            });
+          }
+          // Defensive: chunked() always emits a final `data: undefined` chunk
+          // before completing, but any Observable meeting the same contract
+          // (e.g. a test double) may complete without one.
+          deliver({ done: true });
+        },
+      });
+
+    if (!signal) {
+      return;
+    }
+
+    const onAbort = () => {
+      subscription.unsubscribe();
+      const abortError = Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' });
+      if (!settled) {
+        settled = true;
+        reject(abortError);
+      } else {
+        fail(abortError);
+      }
+    };
+
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
 }
 
 export async function readSearchStream<T>(
@@ -312,46 +434,43 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
       endpoint === 'label_names'
         ? getRangeSnapInterval(this.datasource.cacheLevel, timeRange)
         : this.datasource.getAdjustedInterval(timeRange);
-    const params = new URLSearchParams({
+    const params: Record<string, string> = {
       start: String(timeParams.start),
       end: String(timeParams.end),
       limit: String(this.getEffectiveSearchLimit(options.limit)),
-    });
+    };
 
     if (term) {
-      params.append('search[]', term);
-      params.set('sort_by', 'score');
+      params['search[]'] = term;
+      params.sort_by = 'score';
     }
     if (options.match) {
-      params.append('match[]', options.match);
+      params['match[]'] = options.match;
     }
     // batch_size only affects streaming granularity, not the result set, so it
     // is applied to every Search API request. A single constant therefore tunes
     // delivery for all consumers; callers may still override it per request.
     const batchSize = options.batchSize ?? SEARCH_STREAM_BATCH_SIZE;
     if (batchSize > 0) {
-      params.set('batch_size', String(batchSize));
+      params.batch_size = String(batchSize);
     }
     for (const [key, value] of Object.entries(extraParams)) {
       if (value !== undefined) {
-        params.set(key, value);
+        params[key] = value;
       }
     }
 
     const uid = encodeURIComponent(this.datasource.uid);
-    const appSubUrl = config.appSubUrl?.replace(/\/$/, '') ?? '';
-    // getBackendSrv materializes response bodies, so native fetch is required
-    // here to retain browser ReadableStream access. appSubUrl keeps hosted
-    // Grafana installations under a subpath working.
-    const response = await fetch(
-      `${appSubUrl}/api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}?${params.toString()}`,
-      {
-        method: 'GET',
-        credentials: 'same-origin',
-        signal: options.signal,
-      }
-    );
-    return readSearchStream<T>(chunkSourceFromResponse(response), options.onBatch);
+    // No leading slash: getBackendSrv().chunked() resolves relative to
+    // <base href>, which already accounts for a Grafana subpath install.
+    const url = `api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}`;
+
+    const { source, cancel } = await bridgeChunkedResponse({ url, method: 'GET', params }, options.signal);
+    try {
+      return await readSearchStream<T>(source, options.onBatch);
+    } finally {
+      cancel();
+    }
   }
 
   private getEffectiveSearchLimit(limit?: number): number {

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -58,6 +58,8 @@ interface SearchErrorLine {
   error?: string;
 }
 
+// Mid-stream failures keep the records already delivered to onBatch available
+// to callers while still surfacing the upstream error.
 export class SearchApiError<T = unknown> extends Error {
   constructor(
     message: string,
@@ -108,6 +110,8 @@ export async function readSearchStream<T>(
       parsed = JSON.parse(line);
     } catch (error) {
       if (tolerateIncomplete) {
+        // Abrupt EOF is valid for this API. Ignore only the unfinished final
+        // line; malformed newline-terminated records still fail loudly.
         return;
       }
       throw error;
@@ -129,10 +133,14 @@ export async function readSearchStream<T>(
       if (parsed.warnings) {
         warnings.push(...parsed.warnings);
       }
+      // Incremental consumers render this batch immediately; conventional
+      // callers still receive the accumulated result when the stream ends.
       onBatch?.(parsed.results);
     }
   };
 
+  // HTTP chunk boundaries are unrelated to NDJSON line boundaries, so retain
+  // the final fragment and prepend it to the next decoded chunk.
   while (true) {
     const { done, value } = await reader.read();
     if (done) {
@@ -152,6 +160,8 @@ export async function readSearchStream<T>(
   return { results, warnings, hasMore };
 }
 
+// This client preserves ResourceApiClient's string-array contract for existing
+// consumers and exposes structured streaming methods to search-aware UIs.
 export class SearchApiClient extends BaseResourceClient implements ResourceApiClient {
   private _cache: ResourceClientsCache = new ResourceClientsCache(this.datasource.cacheLevel);
 
@@ -199,6 +209,8 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
   ): Promise<string[]> => {
     const effectiveLimit = this.getEffectiveSearchLimit(limit);
     const interpolatedName = this.datasource.interpolateString(labelKey);
+    // Unlike the legacy /label/{name}/values endpoint, Search API carries the
+    // label name in a query parameter and therefore expects the unescaped name.
     const labelName = removeQuotesIfExist(interpolatedName);
     const effectiveMatch = `${match ?? ''}-${labelName}`;
     const cached = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
@@ -271,6 +283,9 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
 
     const uid = encodeURIComponent(this.datasource.uid);
     const appSubUrl = config.appSubUrl?.replace(/\/$/, '') ?? '';
+    // getBackendSrv materializes response bodies, so native fetch is required
+    // here to retain browser ReadableStream access. appSubUrl keeps hosted
+    // Grafana installations under a subpath working.
     const response = await fetch(
       `${appSubUrl}/api/datasources/uid/${uid}/resources/api/v1/search/${endpoint}?${params.toString()}`,
       {
@@ -284,6 +299,9 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
 
   private getEffectiveSearchLimit(limit?: number): number {
     const effectiveLimit = this.getEffectiveLimit(limit);
+    // Legacy discovery treats zero as unlimited and defaults to 40,000.
+    // Search API requires a positive limit and Prometheus caps it at 10,000 by
+    // default, so normalize both values before the request reaches upstream.
     if (effectiveLimit <= 0) {
       return DEFAULT_SEARCH_API_MAX_LIMIT;
     }

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -474,11 +474,30 @@ export class SearchApiClient extends BaseResourceClient implements ResourceApiCl
       headers['X-Grafana-Org-Id'] = String(orgId);
     }
 
-    const { source, cancel } = await bridgeChunkedResponse({ url, method: 'GET', params, headers }, options.signal);
+    const request: BackendSrvRequest = { url, method: 'GET', params, headers };
+    let { source, cancel } = await bridgeChunkedResponse(request, options.signal);
+    if (source.status === 401) {
+      // chunked() doesn't run the core pipeline's single-flight token
+      // rotation, so approximate it: a login ping runs that full pipeline
+      // (including rotation) as a side effect, then the request is replayed
+      // once. Give up after one retry, same as the core 401 handling.
+      cancel();
+      await this.pingLoginToRefreshSession();
+      ({ source, cancel } = await bridgeChunkedResponse(request, options.signal));
+    }
     try {
       return await readSearchStream<T>(source, options.onBatch);
     } finally {
       cancel();
+    }
+  }
+
+  private async pingLoginToRefreshSession(): Promise<void> {
+    try {
+      await getBackendSrv().get('/api/login/ping');
+    } catch {
+      // If the session truly can't be refreshed, the retried request will
+      // surface its own 401 as a SearchApiError.
     }
   }
 

--- a/packages/grafana-prometheus/src/search_api_client.ts
+++ b/packages/grafana-prometheus/src/search_api_client.ts
@@ -7,6 +7,12 @@ import { BaseResourceClient, type ResourceApiClient, ResourceClientsCache } from
 
 const DEFAULT_SEARCH_API_MAX_LIMIT = 10_000;
 
+// Upper bound on a single NDJSON line held in memory before a newline arrives.
+// A legitimate batch is capped by batch_size, so this only guards against a
+// misbehaving upstream that never terminates a line. Comfortably above the
+// largest realistic single-batch line (limit 10k results with metadata).
+const MAX_SEARCH_STREAM_LINE_LENGTH = 32 * 1024 * 1024;
+
 export interface SearchMetricResult {
   name: string;
   score?: number;
@@ -78,7 +84,8 @@ export class SearchApiError<T = unknown> extends Error {
 
 export async function readSearchStream<T>(
   response: Response,
-  onBatch?: (results: T[]) => void
+  onBatch?: (results: T[]) => void,
+  maxLineLength: number = MAX_SEARCH_STREAM_LINE_LENGTH
 ): Promise<SearchStreamResult<T>> {
   if (!response.ok) {
     let error: SearchErrorLine | undefined;
@@ -161,6 +168,13 @@ export async function readSearchStream<T>(
     buffer = lines.pop() ?? '';
     for (const line of lines) {
       processLine(line, false);
+    }
+    // Fail fast on an unterminated line rather than buffering without bound.
+    if (buffer.length > maxLineLength) {
+      throw new SearchApiError(
+        `Search stream line exceeded the maximum length of ${maxLineLength} bytes`,
+        results.slice()
+      );
     }
   }
 

--- a/packages/grafana-prometheus/src/types.ts
+++ b/packages/grafana-prometheus/src/types.ts
@@ -49,7 +49,7 @@ export interface PromOptions extends DataSourceJsonData {
   allowAsRecordingRulesTarget?: boolean;
   oauthPassThru?: boolean;
   seriesEndpoint?: boolean;
-  searchApi?: boolean;
+  enableSearchApi?: boolean;
   seriesLimit?: number;
   maxSamplesProcessedWarningThreshold?: number;
   maxSamplesProcessedErrorThreshold?: number;

--- a/packages/grafana-prometheus/src/types.ts
+++ b/packages/grafana-prometheus/src/types.ts
@@ -49,6 +49,7 @@ export interface PromOptions extends DataSourceJsonData {
   allowAsRecordingRulesTarget?: boolean;
   oauthPassThru?: boolean;
   seriesEndpoint?: boolean;
+  searchApi?: boolean;
   seriesLimit?: number;
   maxSamplesProcessedWarningThreshold?: number;
   maxSamplesProcessedErrorThreshold?: number;

--- a/pkg/promlib/client/client.go
+++ b/pkg/promlib/client/client.go
@@ -137,6 +137,9 @@ func (c *Client) QueryResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return nil, err
 	}
+	if acceptEncoding := req.GetHTTPHeaders().Get("Accept-Encoding"); acceptEncoding != "" {
+		httpRequest.Header.Set("Accept-Encoding", acceptEncoding)
+	}
 
 	return c.doer.Do(httpRequest)
 }

--- a/pkg/promlib/client/client.go
+++ b/pkg/promlib/client/client.go
@@ -137,6 +137,8 @@ func (c *Client) QueryResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return nil, err
 	}
+	// Resource handlers opt into a specific encoding policy. Search streaming
+	// uses identity so the caller can forward bytes without buffering a decode.
 	if acceptEncoding := req.GetHTTPHeaders().Get("Accept-Encoding"); acceptEncoding != "" {
 		httpRequest.Header.Set("Accept-Encoding", acceptEncoding)
 	}

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -145,6 +145,8 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	}
 
 	switch {
+	case strings.HasPrefix(strings.TrimPrefix(req.Path, "/"), "api/v1/search/"):
+		return i.resource.ExecuteSearch(ctx, req, sender)
 	case strings.EqualFold(req.Path, "suggestions"):
 		resp, err := i.resource.GetSuggestions(ctx, req)
 		if err != nil {

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -146,6 +146,8 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 
 	switch {
 	case strings.HasPrefix(strings.TrimPrefix(req.Path, "/"), "api/v1/search/"):
+		// Search responses are NDJSON streams and must bypass the catch-all
+		// Execute path, which buffers and decodes the complete response.
 		return i.resource.ExecuteSearch(ctx, req, sender)
 	case strings.EqualFold(req.Path, "suggestions"):
 		resp, err := i.resource.GetSuggestions(ctx, req)

--- a/pkg/promlib/library_test.go
+++ b/pkg/promlib/library_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeSender struct{}
+type fakeSender struct {
+	Responses []*backend.CallResourceResponse
+}
 
 func (sender *fakeSender) Send(resp *backend.CallResourceResponse) error {
+	sender.Responses = append(sender.Responses, resp)
 	return nil
 }
 
@@ -30,7 +33,7 @@ func (rt *fakeRoundtripper) RoundTrip(req *http.Request) (*http.Response, error)
 		Status:        "200",
 		StatusCode:    200,
 		Header:        nil,
-		Body:          nil,
+		Body:          io.NopCloser(http.NoBody),
 		ContentLength: 0,
 	}, nil
 }
@@ -129,6 +132,27 @@ func TestService(t *testing.T) {
 		err := service.CallResource(context.Background(), req, sender)
 		require.NoError(t, err)
 		require.Equal(t, `http://localhost:9090/api/v1/labels?end=2022-06-01T12%3A00%3A00Z&limit=10&match%5B%5D=go_cgo_go_to_c_calls_calls_total%7Bjob%3D~%22.%2B%22%7D&match%5B%5D=up%7Bjob%3D~%22.%2B%22%7D&start=2022-06-01T00%3A00%3A00Z`, f.Roundtripper.Req.URL.String())
+	})
+
+	t.Run("search resource uses streaming handler", func(t *testing.T) {
+		f := &fakeHTTPClientProvider{}
+		httpProvider := getMockPromTestSDKProvider(f)
+		service := NewService(httpProvider, backend.NewLoggerWith("logger", "test"), mockExtendTransportOptions)
+
+		req := mockRequest()
+		req.Path = "api/v1/search/metric_names"
+		req.URL = "/api/v1/search/metric_names?limit=100"
+		req.Method = http.MethodGet
+		req.Body = nil
+		sender := &fakeSender{}
+
+		err := service.CallResource(context.Background(), req, sender)
+
+		require.NoError(t, err)
+		require.Equal(t, "identity", f.Roundtripper.Req.Header.Get("Accept-Encoding"))
+		require.Equal(t, "http://localhost:9090/api/v1/search/metric_names?limit=100", f.Roundtripper.Req.URL.String())
+		require.Len(t, sender.Responses, 1)
+		require.Equal(t, "application/x-ndjson; charset=utf-8", http.Header(sender.Responses[0].Headers).Get("Content-Type"))
 	})
 }
 

--- a/pkg/promlib/library_test.go
+++ b/pkg/promlib/library_test.go
@@ -149,7 +149,7 @@ func TestService(t *testing.T) {
 		err := service.CallResource(context.Background(), req, sender)
 
 		require.NoError(t, err)
-		require.Equal(t, "identity", f.Roundtripper.Req.Header.Get("Accept-Encoding"))
+		require.Equal(t, "gzip", f.Roundtripper.Req.Header.Get("Accept-Encoding"))
 		require.Equal(t, "http://localhost:9090/api/v1/search/metric_names?limit=100", f.Roundtripper.Req.URL.String())
 		require.Len(t, sender.Responses, 1)
 		require.Equal(t, "application/x-ndjson; charset=utf-8", http.Header(sender.Responses[0].Headers).Get("Content-Type"))

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -11,6 +11,11 @@ import (
 
 const searchStreamBufferSize = 16 * 1024
 
+// MaxSearchErrorBodyBytes caps how much of an upstream error response is read
+// into memory. Search errors are small Prometheus JSON payloads, so this only
+// guards against a misbehaving upstream returning an unbounded error body.
+const MaxSearchErrorBodyBytes = 1 << 20 // 1 MiB
+
 // ExecuteSearch streams a Prometheus search API response without buffering it.
 func (r *Resource) ExecuteSearch(
 	ctx context.Context,
@@ -35,7 +40,9 @@ func (r *Resource) ExecuteSearch(
 	if resp.StatusCode != http.StatusOK {
 		// Errors are small, non-streaming Prometheus JSON responses. Sending the
 		// body once preserves the upstream status and message for Grafana's UI.
-		body, err := io.ReadAll(resp.Body)
+		// The read is bounded so a misbehaving upstream cannot force unbounded
+		// buffering here.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, MaxSearchErrorBodyBytes))
 		if err != nil {
 			return fmt.Errorf("error reading search error response: %v", err)
 		}

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,6 +92,11 @@ func (r *Resource) ExecuteSearch(
 			}
 			// The Search API permits abrupt EOF. Results already forwarded remain
 			// useful, so a transport read error ends the partial stream cleanly.
+			// A non-EOF error (e.g. a reset connection) is still logged so the
+			// truncation is observable rather than silently swallowed.
+			if !errors.Is(readErr, io.EOF) {
+				r.log.FromContext(ctx).Warn("Search stream ended with a transport error", "err", readErr)
+			}
 			return nil
 		}
 	}

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -45,6 +45,9 @@ func (r *Resource) ExecuteSearch(
 	}
 
 	headers := resp.Header.Clone()
+	if headers == nil {
+		headers = make(http.Header)
+	}
 	headers.Set("Content-Type", "application/x-ndjson; charset=utf-8")
 	headers.Del("Content-Length")
 	headers.Del("Content-Encoding")

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -46,9 +46,16 @@ func (r *Resource) ExecuteSearch(
 		if err != nil {
 			return fmt.Errorf("error reading search error response: %v", err)
 		}
+		// The buffered body no longer matches the upstream framing/encoding
+		// headers, so strip them to avoid a length/encoding mismatch that a
+		// downstream proxy would reject.
+		errorHeaders := resp.Header.Clone()
+		errorHeaders.Del("Content-Length")
+		errorHeaders.Del("Content-Encoding")
+		errorHeaders.Del("Transfer-Encoding")
 		return sender.Send(&backend.CallResourceResponse{
 			Status:  resp.StatusCode,
-			Headers: resp.Header,
+			Headers: errorHeaders,
 			Body:    body,
 		})
 	}

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -24,9 +24,6 @@ func (r *Resource) ExecuteSearch(
 	// decompression step such as the one used by Resource.Execute.
 	streamReq := *req
 	streamReq.Headers = map[string][]string(req.GetHTTPHeaders().Clone())
-	if streamReq.Headers == nil {
-		streamReq.Headers = make(map[string][]string)
-	}
 	streamReq.Headers["Accept-Encoding"] = []string{"identity"}
 
 	resp, err := r.promClient.QueryResource(ctx, &streamReq)
@@ -50,9 +47,6 @@ func (r *Resource) ExecuteSearch(
 	}
 
 	headers := resp.Header.Clone()
-	if headers == nil {
-		headers = make(http.Header)
-	}
 	headers.Set("Content-Type", "application/x-ndjson; charset=utf-8")
 	headers.Del("Content-Length")
 	headers.Del("Content-Encoding")

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -1,0 +1,76 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+const searchStreamBufferSize = 16 * 1024
+
+// ExecuteSearch streams a Prometheus search API response without buffering it.
+func (r *Resource) ExecuteSearch(
+	ctx context.Context,
+	req *backend.CallResourceRequest,
+	sender backend.CallResourceResponseSender,
+) error {
+	r.log.FromContext(ctx).Debug("Sending search resource query", "URL", req.URL)
+
+	streamReq := *req
+	streamReq.Headers = map[string][]string(req.GetHTTPHeaders().Clone())
+	if streamReq.Headers == nil {
+		streamReq.Headers = make(map[string][]string)
+	}
+	streamReq.Headers["Accept-Encoding"] = []string{"identity"}
+
+	resp, err := r.promClient.QueryResource(ctx, &streamReq)
+	if err != nil {
+		return fmt.Errorf("error querying search resource: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error reading search error response: %v", err)
+		}
+		return sender.Send(&backend.CallResourceResponse{
+			Status:  resp.StatusCode,
+			Headers: resp.Header,
+			Body:    body,
+		})
+	}
+
+	headers := resp.Header.Clone()
+	headers.Set("Content-Type", "application/x-ndjson; charset=utf-8")
+	headers.Del("Content-Length")
+	headers.Del("Content-Encoding")
+	headers.Del("Transfer-Encoding")
+
+	if err := sender.Send(&backend.CallResourceResponse{
+		Status:  resp.StatusCode,
+		Headers: headers,
+	}); err != nil {
+		return err
+	}
+
+	buffer := make([]byte, searchStreamBufferSize)
+	for {
+		n, readErr := resp.Body.Read(buffer)
+		if n > 0 {
+			chunk := append([]byte(nil), buffer[:n]...)
+			if err := sender.Send(&backend.CallResourceResponse{Body: chunk}); err != nil {
+				return err
+			}
+		}
+		if readErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return nil
+		}
+	}
+}

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -19,6 +19,9 @@ func (r *Resource) ExecuteSearch(
 ) error {
 	r.log.FromContext(ctx).Debug("Sending search resource query", "URL", req.URL)
 
+	// Clone the request because it may be reused by the caller. Search responses
+	// must stay uncompressed so chunks can be forwarded without a buffering
+	// decompression step such as the one used by Resource.Execute.
 	streamReq := *req
 	streamReq.Headers = map[string][]string(req.GetHTTPHeaders().Clone())
 	if streamReq.Headers == nil {
@@ -33,6 +36,8 @@ func (r *Resource) ExecuteSearch(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// Errors are small, non-streaming Prometheus JSON responses. Sending the
+		// body once preserves the upstream status and message for Grafana's UI.
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("error reading search error response: %v", err)
@@ -53,6 +58,8 @@ func (r *Resource) ExecuteSearch(
 	headers.Del("Content-Encoding")
 	headers.Del("Transfer-Encoding")
 
+	// Grafana applies status and headers only from the first streamed response.
+	// Later Send calls intentionally contain body bytes only.
 	if err := sender.Send(&backend.CallResourceResponse{
 		Status:  resp.StatusCode,
 		Headers: headers,
@@ -64,6 +71,7 @@ func (r *Resource) ExecuteSearch(
 	for {
 		n, readErr := resp.Body.Read(buffer)
 		if n > 0 {
+			// Send may outlive this iteration, so do not expose the reusable read buffer.
 			chunk := append([]byte(nil), buffer[:n]...)
 			if err := sender.Send(&backend.CallResourceResponse{Body: chunk}); err != nil {
 				return err
@@ -73,6 +81,8 @@ func (r *Resource) ExecuteSearch(
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			// The Search API permits abrupt EOF. Results already forwarded remain
+			// useful, so a transport read error ends the partial stream cleanly.
 			return nil
 		}
 	}

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -61,7 +61,13 @@ func (r *Resource) ExecuteSearch(
 		})
 	}
 
+	// resp.Header may be nil (a RoundTripper is permitted to return one), and
+	// http.Header(nil).Clone() stays nil, so start from an empty header set to
+	// keep the writes below safe.
 	headers := resp.Header.Clone()
+	if headers == nil {
+		headers = http.Header{}
+	}
 	headers.Set("Content-Type", "application/x-ndjson; charset=utf-8")
 	headers.Del("Content-Length")
 	headers.Del("Content-Encoding")

--- a/pkg/promlib/resource/search.go
+++ b/pkg/promlib/resource/search.go
@@ -1,11 +1,13 @@
 package resource
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -25,12 +27,14 @@ func (r *Resource) ExecuteSearch(
 ) error {
 	r.log.FromContext(ctx).Debug("Sending search resource query", "URL", req.URL)
 
-	// Clone the request because it may be reused by the caller. Search responses
-	// must stay uncompressed so chunks can be forwarded without a buffering
-	// decompression step such as the one used by Resource.Execute.
+	// Clone the request because it may be reused by the caller. Pin the upstream
+	// encoding to gzip: the browser's Accept-Encoding (gzip, deflate, br, zstd)
+	// is forwarded to the datasource by the SDK header middleware, and Go only
+	// transparently decompresses gzip. Requesting gzip explicitly keeps the wire
+	// compressed while letting us decode it with a streaming gzip.Reader below.
 	streamReq := *req
 	streamReq.Headers = map[string][]string(req.GetHTTPHeaders().Clone())
-	streamReq.Headers["Accept-Encoding"] = []string{"identity"}
+	streamReq.Headers["Accept-Encoding"] = []string{"gzip"}
 
 	resp, err := r.promClient.QueryResource(ctx, &streamReq)
 	if err != nil {
@@ -73,6 +77,19 @@ func (r *Resource) ExecuteSearch(
 	headers.Del("Content-Encoding")
 	headers.Del("Transfer-Encoding")
 
+	// We requested gzip explicitly, so Go's transport does not auto-decompress.
+	// Decode it here with a streaming reader that yields plaintext NDJSON without
+	// buffering the whole body. Any other encoding is forwarded as-is.
+	body := io.Reader(resp.Body)
+	if strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error creating gzip reader for search stream: %v", err)
+		}
+		defer gzReader.Close()
+		body = gzReader
+	}
+
 	// Grafana applies status and headers only from the first streamed response.
 	// Later Send calls intentionally contain body bytes only.
 	if err := sender.Send(&backend.CallResourceResponse{
@@ -84,7 +101,7 @@ func (r *Resource) ExecuteSearch(
 
 	buffer := make([]byte, searchStreamBufferSize)
 	for {
-		n, readErr := resp.Body.Read(buffer)
+		n, readErr := body.Read(buffer)
 		if n > 0 {
 			// Send may outlive this iteration, so do not expose the reusable read buffer.
 			chunk := append([]byte(nil), buffer[:n]...)

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -197,12 +198,68 @@ func TestResourceExecuteSearchReturnsSenderError(t *testing.T) {
 	require.ErrorIs(t, err, senderErr)
 }
 
+func TestResourceExecuteSearchLogsNonEOFReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Promise more bytes than we deliver, then abandon the connection so the
+		// client sees an unexpected EOF rather than a clean end of stream.
+		w.Header().Set("Content-Length", "999")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{\"results\":[\"up\"]}\n"))
+		w.(http.Flusher).Flush()
+	}))
+	defer server.Close()
+
+	logger := &recordingLogger{}
+	res := newSearchResourceWithLogger(t, server.URL, logger)
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(_ *backend.CallResourceResponse) error {
+		return nil
+	}))
+
+	// A truncated stream ends the partial response cleanly, but the transport
+	// error must still be observable in the logs.
+	require.NoError(t, err)
+	require.True(t, logger.hasWarning(), "expected a warning to be logged for the non-EOF read error")
+}
+
 func newSearchResource(t *testing.T, serverURL string) *resource.Resource {
+	t.Helper()
+	return newSearchResourceWithLogger(t, serverURL, log.DefaultLogger)
+}
+
+func newSearchResourceWithLogger(t *testing.T, serverURL string, logger log.Logger) *resource.Resource {
 	t.Helper()
 	res, err := resource.New(http.DefaultClient, backend.DataSourceInstanceSettings{
 		URL:      serverURL,
 		JSONData: []byte(`{"httpMethod":"GET"}`),
-	}, log.DefaultLogger)
+	}, logger)
 	require.NoError(t, err)
 	return res
+}
+
+// recordingLogger captures Warn calls so tests can assert on logged transport
+// errors without inspecting stderr.
+type recordingLogger struct {
+	log.Logger
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (l *recordingLogger) Warn(msg string, _ ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, msg)
+}
+
+func (l *recordingLogger) Debug(_ string, _ ...interface{}) {}
+
+func (l *recordingLogger) FromContext(_ context.Context) log.Logger { return l }
+
+func (l *recordingLogger) hasWarning() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.warnings) > 0
 }

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -197,6 +198,41 @@ func TestResourceExecuteSearchReturnsSenderError(t *testing.T) {
 
 	require.ErrorIs(t, err, senderErr)
 }
+
+func TestResourceExecuteSearchHandlesNilResponseHeader(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		// A RoundTripper is allowed to return a response with a nil Header.
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     nil,
+			Body:       io.NopCloser(strings.NewReader("{\"results\":[\"up\"]}\n")),
+		}, nil
+	})}
+	res, err := resource.New(client, backend.DataSourceInstanceSettings{
+		URL:      "http://prometheus.example",
+		JSONData: []byte(`{"httpMethod":"GET"}`),
+	}, log.DefaultLogger)
+	require.NoError(t, err)
+
+	var responses []*backend.CallResourceResponse
+	err = res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(responses), 1)
+	require.Equal(t, http.StatusOK, responses[0].Status)
+	require.Equal(t, "application/x-ndjson; charset=utf-8", http.Header(responses[0].Headers).Get("Content-Type"))
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestResourceExecuteSearchLogsNonEOFReadError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -1,6 +1,8 @@
 package resource_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
@@ -49,7 +51,7 @@ func TestResourceExecuteSearchStreamsResponse(t *testing.T) {
 	}))
 
 	require.NoError(t, err)
-	require.Equal(t, "identity", <-acceptEncoding)
+	require.Equal(t, "gzip", <-acceptEncoding)
 	require.GreaterOrEqual(t, len(responses), 3)
 	require.Equal(t, http.StatusOK, responses[0].Status)
 	require.Equal(t, "application/x-ndjson; charset=utf-8", http.Header(responses[0].Headers).Get("Content-Type"))
@@ -65,6 +67,46 @@ func TestResourceExecuteSearchStreamsResponse(t *testing.T) {
 		"{\"results\":[\"http_requests_total\"]}\n{\"status\":\"success\",\"has_more\":false}\n",
 		body.String(),
 	)
+}
+
+func TestResourceExecuteSearchDecodesGzipResponse(t *testing.T) {
+	payload := "{\"results\":[\"up\"]}\n{\"status\":\"success\",\"has_more\":false}\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "gzip", req.Header.Get("Accept-Encoding"))
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write([]byte(payload))
+		require.NoError(t, gz.Close())
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	var responses []*backend.CallResourceResponse
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(responses), 2)
+	// The forwarded body must be decompressed plaintext NDJSON, and the encoding
+	// header must not advertise gzip for the now-plaintext bytes.
+	require.Empty(t, http.Header(responses[0].Headers).Get("Content-Encoding"))
+
+	var body strings.Builder
+	for _, resp := range responses[1:] {
+		body.Write(resp.Body)
+	}
+	require.Equal(t, payload, body.String())
 }
 
 func TestResourceExecuteSearchPassesThroughErrorResponse(t *testing.T) {

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -92,6 +92,39 @@ func TestResourceExecuteSearchPassesThroughErrorResponse(t *testing.T) {
 	require.Equal(t, "application/json", http.Header(responses[0].Headers).Get("Content-Type"))
 }
 
+func TestResourceExecuteSearchStripsFramingHeadersFromErrorResponse(t *testing.T) {
+	errorBody := `{"status":"error","error":"boom"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(errorBody))
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	var responses []*backend.CallResourceResponse
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+	require.Equal(t, http.StatusBadGateway, responses[0].Status)
+	require.Equal(t, errorBody, string(responses[0].Body))
+	require.Equal(t, "application/json", http.Header(responses[0].Headers).Get("Content-Type"))
+	// Stale framing headers describe the upstream payload, not what we forward,
+	// so a downstream proxy would reject the mismatch.
+	require.Empty(t, http.Header(responses[0].Headers).Get("Content-Encoding"))
+	require.Empty(t, http.Header(responses[0].Headers).Get("Content-Length"))
+	require.Empty(t, http.Header(responses[0].Headers).Get("Transfer-Encoding"))
+}
+
 func TestResourceExecuteSearchLimitsErrorBodySize(t *testing.T) {
 	oversized := strings.Repeat("x", resource.MaxSearchErrorBodyBytes+1024)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -1,0 +1,149 @@
+package resource_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/resource"
+)
+
+func TestResourceExecuteSearchStreamsResponse(t *testing.T) {
+	acceptEncoding := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		acceptEncoding <- req.Header.Get("Accept-Encoding")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "999")
+		w.Header().Set("Content-Encoding", "identity")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("{\"results\":[\"http_requests_total\"]}\n"))
+		flusher.Flush()
+		time.Sleep(10 * time.Millisecond)
+		_, _ = w.Write([]byte("{\"status\":\"success\",\"has_more\":false}\n"))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	var responses []*backend.CallResourceResponse
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names?limit=100",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.Equal(t, "identity", <-acceptEncoding)
+	require.GreaterOrEqual(t, len(responses), 3)
+	require.Equal(t, http.StatusOK, responses[0].Status)
+	require.Equal(t, "application/x-ndjson; charset=utf-8", http.Header(responses[0].Headers).Get("Content-Type"))
+	require.Empty(t, http.Header(responses[0].Headers).Get("Content-Length"))
+	require.Empty(t, http.Header(responses[0].Headers).Get("Content-Encoding"))
+	require.Empty(t, http.Header(responses[0].Headers).Get("Transfer-Encoding"))
+
+	var body strings.Builder
+	for _, resp := range responses[1:] {
+		body.Write(resp.Body)
+	}
+	require.Equal(t,
+		"{\"results\":[\"http_requests_total\"]}\n{\"status\":\"success\",\"has_more\":false}\n",
+		body.String(),
+	)
+}
+
+func TestResourceExecuteSearchPassesThroughErrorResponse(t *testing.T) {
+	errorBody := `{"status":"error","errorType":"unavailable","error":"search API disabled"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(errorBody))
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	var responses []*backend.CallResourceResponse
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+	require.Equal(t, http.StatusInternalServerError, responses[0].Status)
+	require.Equal(t, errorBody, string(responses[0].Body))
+	require.Equal(t, "application/json", http.Header(responses[0].Headers).Get("Content-Type"))
+}
+
+func TestResourceExecuteSearchStopsOnCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{\"results\":[\"up\"]}\n"))
+		w.(http.Flusher).Flush()
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := res.ExecuteSearch(ctx, &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		if len(resp.Body) > 0 {
+			cancel()
+		}
+		return nil
+	}))
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResourceExecuteSearchReturnsSenderError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	senderErr := errors.New("send failed")
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(_ *backend.CallResourceResponse) error {
+		return senderErr
+	}))
+
+	require.ErrorIs(t, err, senderErr)
+}
+
+func newSearchResource(t *testing.T, serverURL string) *resource.Resource {
+	t.Helper()
+	res, err := resource.New(http.DefaultClient, backend.DataSourceInstanceSettings{
+		URL:      serverURL,
+		JSONData: []byte(`{"httpMethod":"GET"}`),
+	}, log.DefaultLogger)
+	require.NoError(t, err)
+	return res
+}

--- a/pkg/promlib/resource/search_test.go
+++ b/pkg/promlib/resource/search_test.go
@@ -92,6 +92,32 @@ func TestResourceExecuteSearchPassesThroughErrorResponse(t *testing.T) {
 	require.Equal(t, "application/json", http.Header(responses[0].Headers).Get("Content-Type"))
 }
 
+func TestResourceExecuteSearchLimitsErrorBodySize(t *testing.T) {
+	oversized := strings.Repeat("x", resource.MaxSearchErrorBodyBytes+1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(oversized))
+	}))
+	defer server.Close()
+
+	res := newSearchResource(t, server.URL)
+	var responses []*backend.CallResourceResponse
+	err := res.ExecuteSearch(context.Background(), &backend.CallResourceRequest{
+		Method: http.MethodGet,
+		Path:   "api/v1/search/metric_names",
+		URL:    "/api/v1/search/metric_names",
+	}, backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+		responses = append(responses, resp)
+		return nil
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+	require.Equal(t, http.StatusInternalServerError, responses[0].Status)
+	require.Len(t, responses[0].Body, resource.MaxSearchErrorBodyBytes)
+}
+
 func TestResourceExecuteSearchStopsOnCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -1,6 +1,8 @@
 apiVersion: 1
 
 datasources:
+  # Classic datasource: same dev Prometheus, but the streaming search API toggle is OFF.
+  # Use this to compare the existing labels/series autocomplete against the search API one.
   - name: 'prometheus'
     uid: 'prometheus'
     type: 'prometheus'
@@ -12,3 +14,19 @@ datasources:
     editable: true
     jsonData:
       httpMethod: 'GET'
+
+  # Phase 0 datasource that points at the dev Prometheus running with the experimental
+  # NDJSON streaming search API and has the per-datasource toggle enabled. Use this
+  # datasource to manually verify the streaming search autocomplete path.
+  - name: 'prometheus-search-api'
+    uid: 'prometheus-search-api'
+    type: 'prometheus'
+    access: proxy
+    url: 'http://prometheus:9090'
+    isDefault: true
+    orgId: 1
+    version: 1
+    editable: true
+    jsonData:
+      httpMethod: 'GET'
+      enableSearchApi: true

--- a/provisioning/prometheus/prometheus.yml
+++ b/provisioning/prometheus/prometheus.yml
@@ -1,6 +1,7 @@
-# Scrape config for the dev Prometheus. It scrapes itself and the Grafana dev
-# container so there are real metric names, label names and label values to
-# exercise the plugin against.
+# Scrape config for the Phase 0 dev Prometheus that runs with the experimental
+# NDJSON streaming search API enabled (--enable-feature=search-api).
+# It scrapes itself and the Grafana dev container so there are real metric names,
+# label names and label values to exercise the search autocomplete against.
 global:
   scrape_interval: 60s
   evaluation_interval: 60s


### PR DESCRIPTION
> [!IMPORTANT]
> **This is an exploration / proof of concept, not a merge candidate.** It demonstrates end-to-end Prometheus/Mimir Search API streaming over plain HTTP. The implementation still needs to be split into small, reviewable changes and refined before production use.
>
> Parameter handling across autocomplete and discovery consumers is also provisional. Follow-up work must ensure each call site supplies the correct Search API parameters and semantics instead of adapting values intended for the legacy labels/series endpoints.

## What & why

Adds opt-in support for the Prometheus/Mimir NDJSON streaming Search API:

- `/api/v1/search/metric_names`
- `/api/v1/search/label_names`
- `/api/v1/search/label_values`

The Search API provides fuzzy, scored, server-side suggestions and streams results progressively as they are computed.

This PoC integrates it into:

- Query builder metric selection
- Metrics Explorer, including progressive metadata rendering
- Monaco metric, label-name, and label-value completions
- Existing language-provider discovery consumers through the `ResourceApiClient` interface

The feature is gated by the per-data-source **Search API** setting. When enabled, upstream Search API errors are surfaced instead of silently falling back to legacy discovery. Default behavior is unchanged while the setting is disabled.

## Architecture

This implementation uses a chunked HTTP resource request:

```text
Autocomplete / Metrics Explorer
        ↓
SearchApiClient
        ↓ getBackendSrv().chunked()
Grafana data source resource endpoint
        ↓ streaming CallResource
promlib ExecuteSearch
        ↓
Prometheus/Mimir Search API
        ↑ NDJSON batches
Progressive UI updates
```

The backend forwards upstream bytes without buffering the complete response. The frontend parses arbitrary chunk boundaries, emits completed batches immediately, and accumulates the final result.

## How this differs from the earlier PoC

The [earlier streaming PoC (#248)](https://github.com/grafana/grafana-prometheus-datasource/pull/248) used a persistent Grafana Live WebSocket with a custom request/response protocol, per-session channels, mailboxes, request IDs, and per-slot cancellation.

This implementation explores a simpler, socket-free design:

- Each search uses a standard chunked HTTP resource request.
- `getBackendSrv().chunked()` streams bytes directly to the frontend.
- SDK `CallResource` streaming forwards NDJSON without buffering.
- `AbortController` and request contexts propagate cancellation upstream.
- It requires no Grafana Live configuration, WebSocket connectivity, session channels, or backend mailbox lifecycle.
- Authentication, organization context, URL handling, and tracing remain closer to Grafana's normal HTTP request path.

The trade-off is one HTTP request per search instead of multiplexing searches over a persistent connection. This PR is intended to evaluate whether that simpler operational model is preferable before committing to a production architecture.

## Transport behavior

The implementation:

- Uses the public `getBackendSrv().chunked()` API
- Preserves cancellation through the browser, Grafana, plugin, and upstream request
- Includes the active `X-Grafana-Org-Id`
- Retries once after a `401` through Grafana's login-ping flow
- Requests and incrementally decodes gzip upstream
- Bounds error-body and NDJSON line sizes
- Detects streams that end without a success trailer
- Preserves partial results after an allowed abrupt EOF
- Removes stale framing headers before forwarding responses

## Known PoC gaps

The main remaining work is correct, context-specific parameter construction.

Several integrations currently reuse or adapt values intended for legacy labels/series endpoints. Before this becomes production-ready, each consumer must be audited for the correct use of:

- `search[]` versus `match[]`
- Label-name and label-value context
- Time ranges
- Limits and pagination/truncation behavior
- `batch_size`
- `include_metadata`
- Sorting behavior
- Query-builder label selectors and Monaco completion context

There are also some `getBackendSrv().fetch()` behaviors that `chunked()` cannot reproduce through the public plugin API, including device ID injection, fetch queueing, Query Inspector events, JWT URL-login headers, and automatic error toasts. These are considered low-impact for this discovery PoC but need an explicit product decision.

## Dev environment / how to test

The development stack includes Prometheus `v3.13.1` with `--enable-feature=search-api`, a data source with Search API enabled, and a classic data source for comparison.

1. Build the backend:

   ```bash
   mage -v
   ```

2. Build the frontend:

   ```bash
   yarn build
   ```

3. Start the stack:

   ```bash
   yarn server
   ```

4. Use the `prometheus-search-api` data source in Explore and the query builder. Exercise the metric combobox, Metrics Explorer, and Monaco metric/label completions.
5. Confirm results arrive progressively over a chunked HTTP resource request without a Grafana Live WebSocket.
6. Compare with the `prometheus` data source and confirm the classic discovery behavior remains unchanged when the toggle is off.

## What to focus a review on

1. Whether chunked HTTP is the right transport abstraction
2. Cancellation and partial-stream behavior
3. NDJSON parsing and response-size safeguards
4. Compatibility with existing language-provider consumers
5. Parameter semantics at each UI integration point
6. How this PoC should be split into small, independently reviewable PRs