### PR TITLE
Prometheus: add opt-in query statistics

### DIFF
--- a/.changeset/quiet-shirts-brake.md
+++ b/.changeset/quiet-shirts-brake.md
@@ -1,0 +1,5 @@
+---
+'promlib': patch
+---
+
+Request and expose Prometheus query statistics

--- a/.changeset/smooth-comics-give.md
+++ b/.changeset/smooth-comics-give.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Add an opt-in query statistics setting

--- a/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
@@ -1,5 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/configuration/PromSettings.test.tsx
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { type SyntheticEvent } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
@@ -117,6 +117,54 @@ describe('PromSettings', () => {
       render(<PromSettings onOptionsChange={() => {}} options={options} showQuerySamplesProcessedThresholdFields />);
 
       expect(screen.queryByText('Query threshold already set in custom query parameters')).not.toBeInTheDocument();
+    });
+
+    it('should hide query statistics by default', () => {
+      render(<PromSettings onOptionsChange={() => {}} options={defaultProps} />);
+
+      expect(screen.queryByRole('switch', { name: 'Query statistics' })).not.toBeInTheDocument();
+    });
+
+    it('should show query statistics disabled by default when enabled by the consumer', () => {
+      render(<PromSettings onOptionsChange={() => {}} options={defaultProps} showQueryStats />);
+
+      expect(screen.getByRole('switch', { name: 'Query statistics' })).not.toBeChecked();
+    });
+
+    it('should initialize query statistics from saved options', () => {
+      const options = createDefaultConfigOptions();
+      options.jsonData.queryStatsEnabled = true;
+
+      render(<PromSettings onOptionsChange={() => {}} options={options} showQueryStats />);
+
+      expect(screen.getByRole('switch', { name: 'Query statistics' })).toBeChecked();
+    });
+
+    it.each([
+      { initial: false, expected: true },
+      { initial: true, expected: false },
+    ])('should persist query statistics as $expected', ({ initial, expected }) => {
+      const options = createDefaultConfigOptions();
+      options.jsonData.queryStatsEnabled = initial;
+      const onOptionsChange = jest.fn();
+
+      render(<PromSettings onOptionsChange={onOptionsChange} options={options} showQueryStats />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Query statistics' }));
+
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({ queryStatsEnabled: expected }),
+        })
+      );
+    });
+
+    it('should disable query statistics for a read-only data source', () => {
+      const options = createDefaultConfigOptions();
+      options.readOnly = true;
+
+      render(<PromSettings onOptionsChange={() => {}} options={options} showQueryStats />);
+
+      expect(screen.getByRole('switch', { name: 'Query statistics' })).toBeDisabled();
     });
   });
 });

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -39,6 +39,8 @@ type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | '
   hideExemplars?: boolean;
   /** Show fields to configure query samples processed thresholds */
   showQuerySamplesProcessedThresholdFields?: boolean;
+  /** Show the query statistics setting */
+  showQueryStats?: boolean;
 };
 
 const httpOptions = [
@@ -84,7 +86,13 @@ const getOptionsWithDefaults = (options: DataSourceSettings<PromOptions>) => {
 export const PromSettings = (props: Props) => {
   const theme = useTheme2();
   const styles = overhaulStyles(theme);
-  const { onOptionsChange, hidePrometheusTypeVersion, hideExemplars, showQuerySamplesProcessedThresholdFields } = props;
+  const {
+    onOptionsChange,
+    hidePrometheusTypeVersion,
+    hideExemplars,
+    showQuerySamplesProcessedThresholdFields,
+    showQueryStats,
+  } = props;
 
   const editorOptions = [
     {
@@ -616,6 +624,31 @@ export const PromSettings = (props: Props) => {
                 {validateInput(seriesLimit, NON_NEGATIVE_INTEGER_REGEX, seriesLimitError)}
               </>
             </InlineField>
+            {showQueryStats && (
+              <InlineField
+                labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                label={t('grafana-prometheus.configuration.prom-settings.label-query-statistics', 'Query statistics')}
+                tooltip={
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-statistics">
+                    Request query processing statistics and show the total queryable samples in Query Inspector. This
+                    can increase the response payload size.
+                  </Trans>
+                }
+                interactive={true}
+                disabled={optionsWithDefaults.readOnly}
+                className={styles.switchField}
+              >
+                <Switch
+                  value={optionsWithDefaults.jsonData.queryStatsEnabled ?? false}
+                  onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'queryStatsEnabled')}
+                  disabled={optionsWithDefaults.readOnly}
+                  aria-label={t(
+                    'grafana-prometheus.configuration.prom-settings.aria-label-query-statistics',
+                    'Query statistics'
+                  )}
+                />
+              </InlineField>
+            )}
             {showQuerySamplesProcessedThresholdFields && (
               <>
                 {(hasWarningThresholdConflict || hasErrorThresholdConflict) && (

--- a/packages/grafana-prometheus/src/locales/en-US/grafana-prometheus.json
+++ b/packages/grafana-prometheus/src/locales/en-US/grafana-prometheus.json
@@ -157,6 +157,7 @@
         "aria-label-prom-type-type": "{{promType}} type",
         "aria-label-prometheus-type": "Prometheus type",
         "aria-label-query-error-threshold": "Query error threshold",
+        "aria-label-query-statistics": "Query statistics",
         "aria-label-query-warning-threshold": "Query warning threshold",
         "aria-label-select-http-method": "Select HTTP method",
         "editor-options": {
@@ -174,6 +175,7 @@
         "label-prometheus-type": "Prometheus type",
         "label-query-error-threshold": "Query error threshold",
         "label-query-overlap-window": "Query overlap window",
+        "label-query-statistics": "Query statistics",
         "label-query-timeout": "Query timeout",
         "label-query-warning-threshold": "Query warning threshold",
         "label-scrape-interval": "Scrape interval",
@@ -200,6 +202,7 @@
         "tooltip-prometheus-type": "Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos. Changing this field will save your current settings. Certain types of Prometheus supports or does not support various APIs. For example, some types support regex matching for label queries to improve performance. Some types have an API for metadata. If you set this incorrectly you may experience odd behavior when querying metrics and labels. Please check your Prometheus documentation to ensure you enter the correct type.",
         "tooltip-query-error-threshold": "When set, Grafana appends this value to Prometheus query requests as the max_samples_processed_error_threshold URL parameter. Leave empty to omit.",
         "tooltip-query-overlap-window": "Set a duration like {{example1}} or {{example2}} or {{example3}}. Default of {{default}}. This duration will be added to the duration of each incremental request.",
+        "tooltip-query-statistics": "Request query processing statistics and show the total queryable samples in Query Inspector. This can increase the response payload size.",
         "tooltip-query-timeout": "Set the Prometheus query timeout.",
         "tooltip-query-warning-threshold": "When set, Grafana appends this value to Prometheus query requests as the max_samples_processed_warning_threshold URL parameter. Leave empty to omit.",
         "tooltip-scrape-interval": "This interval is how frequently Prometheus scrapes targets. Set this to the typical scrape and evaluation interval configured in your Prometheus config file. If you set this to a greater value than your Prometheus config file interval, Grafana will evaluate the data according to this interval and you will see less data points. Defaults to {{default}}.",

--- a/packages/grafana-prometheus/src/types.ts
+++ b/packages/grafana-prometheus/src/types.ts
@@ -52,6 +52,7 @@ export interface PromOptions extends DataSourceJsonData {
   seriesLimit?: number;
   maxSamplesProcessedWarningThreshold?: number;
   maxSamplesProcessedErrorThreshold?: number;
+  queryStatsEnabled?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {

--- a/pkg/promlib/converter/prom.go
+++ b/pkg/promlib/converter/prom.go
@@ -179,6 +179,8 @@ func readPrometheusData(iter *sdkjsoniter.Iterator, opt Options) backend.DataRes
 	resultType := ""
 	resultTypeFound := false
 	var resultBytes []byte
+	var stats any
+	statsFound := false
 
 	encodingFlags := make([]string, 0)
 
@@ -226,20 +228,11 @@ l1Fields:
 			}
 
 		case "stats":
-			v, err := iter.Read()
+			stats, err = iter.Read()
 			if err != nil {
-				rspErr(err)
+				return rspErr(err)
 			}
-			if len(rsp.Frames) > 0 {
-				meta := rsp.Frames[0].Meta
-				if meta == nil {
-					meta = &data.FrameMeta{}
-					rsp.Frames[0].Meta = meta
-				}
-				meta.Custom = map[string]any{
-					"stats": v,
-				}
-			}
+			statsFound = true
 
 		case "":
 			if err != nil {
@@ -259,7 +252,49 @@ l1Fields:
 		}
 	}
 
+	if statsFound {
+		attachQueryStats(&rsp, stats)
+	}
+
 	return rsp
+}
+
+func attachQueryStats(rsp *backend.DataResponse, stats any) {
+	if len(rsp.Frames) == 0 {
+		rsp.Frames = append(rsp.Frames, data.NewFrame("Query statistics"))
+	}
+
+	frame := rsp.Frames[0]
+	if frame.Meta == nil {
+		frame.Meta = &data.FrameMeta{}
+	}
+
+	custom, ok := frame.Meta.Custom.(map[string]any)
+	if !ok {
+		custom = map[string]any{}
+	}
+	custom["stats"] = stats
+	frame.Meta.Custom = custom
+
+	if total, ok := totalQueryableSamples(stats); ok {
+		frame.Meta.Stats = append(frame.Meta.Stats, data.QueryStat{
+			FieldConfig: data.FieldConfig{DisplayName: "Total queryable samples"},
+			Value:       total,
+		})
+	}
+}
+
+func totalQueryableSamples(stats any) (float64, bool) {
+	statsMap, ok := stats.(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	samples, ok := statsMap["samples"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	total, ok := samples["totalQueryableSamples"].(float64)
+	return total, ok
 }
 
 // will read the result object based on the resultType and return a DataResponse

--- a/pkg/promlib/converter/prom_test.go
+++ b/pkg/promlib/converter/prom_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
@@ -47,6 +48,100 @@ func TestReadPromFrames(t *testing.T) {
 	for _, name := range files {
 		t.Run(name, runScenario(name, Options{}))
 	}
+}
+
+func TestReadPrometheusQueryStats(t *testing.T) {
+	read := func(t *testing.T, payload string) *backend.DataResponse {
+		t.Helper()
+		iter := jsoniter.ParseBytes(sdkjsoniter.ConfigDefault, []byte(payload))
+		rsp := ReadPrometheusStyleResult(iter, Options{})
+		require.NoError(t, rsp.Error)
+		return &rsp
+	}
+
+	instantResult := `[{"metric":{"__name__":"up","instance":"localhost"},"value":[1710000000,"1"]}]`
+	perStep := `[[1710000000,12],[1710000060,18]]`
+
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "stats after result",
+			data: `{"resultType":"vector","result":` + instantResult + `,"stats":{"samples":{"totalQueryableSamples":30,"totalQueryableSamplesPerStep":` + perStep + `}}}`,
+		},
+		{
+			name: "stats before result",
+			data: `{"stats":{"samples":{"totalQueryableSamples":30,"totalQueryableSamplesPerStep":` + perStep + `}},"resultType":"vector","result":` + instantResult + `}`,
+		},
+		{
+			name: "stats and result before result type",
+			data: `{"stats":{"samples":{"totalQueryableSamples":30,"totalQueryableSamplesPerStep":` + perStep + `}},"result":` + instantResult + `,"resultType":"vector"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rsp := read(t, `{"status":"success","data":`+tc.data+`}`)
+			require.Len(t, rsp.Frames, 1)
+			require.NotNil(t, rsp.Frames[0].Meta)
+			require.Equal(t, []data.QueryStat{{
+				FieldConfig: data.FieldConfig{DisplayName: "Total queryable samples"},
+				Value:       30,
+			}}, rsp.Frames[0].Meta.Stats)
+
+			custom, ok := rsp.Frames[0].Meta.Custom.(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "vector", custom["resultType"])
+			rawStats, ok := custom["stats"].(map[string]any)
+			require.True(t, ok)
+			samples, ok := rawStats["samples"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, float64(30), samples["totalQueryableSamples"])
+			require.Len(t, samples["totalQueryableSamplesPerStep"], 2)
+		})
+	}
+
+	t.Run("zero samples is retained as a typed stat", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"vector","result":[],"stats":{"samples":{"totalQueryableSamples":0}}}}`)
+		require.Len(t, rsp.Frames, 1)
+		require.Len(t, rsp.Frames[0].Meta.Stats, 1)
+		require.Equal(t, float64(0), rsp.Frames[0].Meta.Stats[0].Value)
+	})
+
+	t.Run("range stats are attached to the first frame only", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"job":"one"},"values":[[1710000000,"1"]]},{"metric":{"job":"two"},"values":[[1710000000,"2"]]}],"stats":{"samples":{"totalQueryableSamples":2}}}}`)
+		require.Len(t, rsp.Frames, 2)
+		require.Len(t, rsp.Frames[0].Meta.Stats, 1)
+		require.Empty(t, rsp.Frames[1].Meta.Stats)
+	})
+
+	t.Run("empty result creates a metadata-only frame", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"matrix","result":[],"stats":{"samples":{"totalQueryableSamples":7}}}}`)
+		require.Len(t, rsp.Frames, 1)
+		require.Equal(t, "Query statistics", rsp.Frames[0].Name)
+		require.Empty(t, rsp.Frames[0].Fields)
+		require.Equal(t, float64(7), rsp.Frames[0].Meta.Stats[0].Value)
+	})
+
+	t.Run("malformed stats do not fail a valid query", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"vector","result":`+instantResult+`,"stats":"not-an-object"}}`)
+		require.Len(t, rsp.Frames, 1)
+		require.Empty(t, rsp.Frames[0].Meta.Stats)
+		custom := rsp.Frames[0].Meta.Custom.(map[string]any)
+		require.Equal(t, "not-an-object", custom["stats"])
+	})
+
+	t.Run("malformed total omits only the typed stat", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"vector","result":`+instantResult+`,"stats":{"samples":{"totalQueryableSamples":"unknown","totalQueryableSamplesPerStep":`+perStep+`}}}}`)
+		require.Empty(t, rsp.Frames[0].Meta.Stats)
+		custom := rsp.Frames[0].Meta.Custom.(map[string]any)
+		require.NotNil(t, custom["stats"])
+	})
+
+	t.Run("missing stats leaves existing metadata unchanged", func(t *testing.T) {
+		rsp := read(t, `{"status":"success","data":{"resultType":"vector","result":`+instantResult+`}}`)
+		require.Empty(t, rsp.Frames[0].Meta.Stats)
+		require.Equal(t, map[string]any{"resultType": "vector"}, rsp.Frames[0].Meta.Custom)
+	})
 }
 
 func runScenario(name string, opts Options) func(t *testing.T) {

--- a/pkg/promlib/middleware/custom_query_params.go
+++ b/pkg/promlib/middleware/custom_query_params.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
@@ -16,6 +17,8 @@ const (
 	customQueryParametersMiddlewareName = "prom-custom-query-parameters"
 	warningThresholdKey                 = "max_samples_processed_warning_threshold"
 	errorThresholdKey                   = "max_samples_processed_error_threshold"
+	queryStatsKey                       = "stats"
+	queryStatsValue                     = "all"
 )
 
 // CustomQueryParameters returns a middleware that appends user-configured custom
@@ -31,8 +34,9 @@ func CustomQueryParameters(logger log.Logger, jsonData *models.PromOptions) sdkh
 		customQueryParams := jsonData.CustomQueryParameters
 		warnVal := jsonData.MaxSamplesProcessedWarningThreshold
 		errVal := jsonData.MaxSamplesProcessedErrorThreshold
+		queryStatsEnabled := jsonData.QueryStatsEnabled
 
-		if customQueryParams == "" && warnVal == 0 && errVal == 0 {
+		if customQueryParams == "" && warnVal == 0 && errVal == 0 && !queryStatsEnabled {
 			return next
 		}
 
@@ -61,9 +65,16 @@ func CustomQueryParameters(logger log.Logger, jsonData *models.PromOptions) sdkh
 					q.Add(k, value)
 				}
 			}
+			if queryStatsEnabled && isQueryEndpoint(req.URL.Path) {
+				q.Set(queryStatsKey, queryStatsValue)
+			}
 			req.URL.RawQuery = q.Encode()
 
 			return next.RoundTrip(req)
 		})
 	})
+}
+
+func isQueryEndpoint(path string) bool {
+	return strings.HasSuffix(path, "/api/v1/query") || strings.HasSuffix(path, "/api/v1/query_range")
 }

--- a/pkg/promlib/middleware/custom_query_params_test.go
+++ b/pkg/promlib/middleware/custom_query_params_test.go
@@ -225,4 +225,74 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 		require.Equal(t, "42", q.Get(warningThresholdKey))
 		require.Equal(t, "88", q.Get(errorThresholdKey))
 	})
+
+	t.Run("With query statistics disabled should not add stats", func(t *testing.T) {
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"), &models.PromOptions{})
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		req, err := http.NewRequest(http.MethodGet, "http://test.com/api/v1/query?query=up", nil)
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Empty(t, req.URL.Query().Get(queryStatsKey))
+	})
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "GET instant query", method: http.MethodGet, path: "/api/v1/query"},
+		{name: "POST instant query", method: http.MethodPost, path: "/api/v1/query"},
+		{name: "GET range query", method: http.MethodGet, path: "/api/v1/query_range"},
+		{name: "POST range query", method: http.MethodPost, path: "/api/v1/query_range"},
+		{name: "query with workspace base path", method: http.MethodPost, path: "/workspaces/ws-123/api/v1/query"},
+	} {
+		t.Run("With query statistics enabled should add stats for "+tc.name, func(t *testing.T) {
+			mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"), &models.PromOptions{QueryStatsEnabled: true})
+			rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+			req, err := http.NewRequest(tc.method, "http://test.com"+tc.path+"?query=up&existing=value", nil)
+			require.NoError(t, err)
+
+			_, err = rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, queryStatsValue, req.URL.Query().Get(queryStatsKey))
+			require.Equal(t, "up", req.URL.Query().Get("query"))
+			require.Equal(t, "value", req.URL.Query().Get("existing"))
+		})
+	}
+
+	for _, path := range []string{
+		"/api/v1/query_exemplars",
+		"/api/v1/metadata",
+		"/api/v1/labels",
+		"/api/v1/series",
+		"/api/v1/status/buildinfo",
+	} {
+		t.Run("With query statistics enabled should not add stats for "+path, func(t *testing.T) {
+			mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"), &models.PromOptions{QueryStatsEnabled: true})
+			rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+			req, err := http.NewRequest(http.MethodGet, "http://test.com"+path, nil)
+			require.NoError(t, err)
+
+			_, err = rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.Empty(t, req.URL.Query().Get(queryStatsKey))
+		})
+	}
+
+	t.Run("Explicit query statistics setting should override a custom stats value", func(t *testing.T) {
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"), &models.PromOptions{
+			CustomQueryParameters: "stats=none&timeout=30s",
+			QueryStatsEnabled:     true,
+		})
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		req, err := http.NewRequest(http.MethodPost, "http://test.com/api/v1/query_range", nil)
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, []string{queryStatsValue}, req.URL.Query()[queryStatsKey])
+		require.Equal(t, "30s", req.URL.Query().Get("timeout"))
+	})
 }

--- a/pkg/promlib/middleware/custom_query_params_test.go
+++ b/pkg/promlib/middleware/custom_query_params_test.go
@@ -269,7 +269,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 		"/api/v1/series",
 		"/api/v1/status/buildinfo",
 	} {
-		t.Run("With query statistics enabled should not add stats for "+path, func(t *testing.T) {
+		t.Run("With query statistics enabled should not add stats to non-query endpoint "+path, func(t *testing.T) {
 			mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"), &models.PromOptions{QueryStatsEnabled: true})
 			rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 			req, err := http.NewRequest(http.MethodGet, "http://test.com"+path, nil)

--- a/pkg/promlib/models/settings.go
+++ b/pkg/promlib/models/settings.go
@@ -34,6 +34,7 @@ type PromOptions struct {
 	CustomQueryParameters               string  `json:"customQueryParameters"`
 	MaxSamplesProcessedWarningThreshold float64 `json:"maxSamplesProcessedWarningThreshold"`
 	MaxSamplesProcessedErrorThreshold   float64 `json:"maxSamplesProcessedErrorThreshold"`
+	QueryStatsEnabled                   bool    `json:"queryStatsEnabled"`
 
 	// Frontend only types
 	PrometheusType                string                       `json:"prometheusType"`

--- a/pkg/promlib/models/settings_test.go
+++ b/pkg/promlib/models/settings_test.go
@@ -108,6 +108,26 @@ func TestParsePromOptions_EmptyJSONData(t *testing.T) {
 	}
 }
 
+func TestParsePromOptions_QueryStatsEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		json map[string]any
+		want bool
+	}{
+		{name: "true", json: map[string]any{"queryStatsEnabled": true}, want: true},
+		{name: "false", json: map[string]any{"queryStatsEnabled": false}, want: false},
+		{name: "missing defaults to false", json: map[string]any{}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := models.ParsePromOptions(settingsWithJSON(t, tc.json))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, opts.QueryStatsEnabled)
+		})
+	}
+}
+
 func TestPromOptions_ApplyDefaults(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## What changed

- Add an opt-in **Query statistics** setting to shared Prometheus configuration.
- Add `stats=all` only to instant and range query endpoints when enabled.
- Expose `samples.totalQueryableSamples` in frame query stats for Query Inspector.
- Preserve the complete raw Prometheus statistics payload in frame metadata.
- Cover the setting, middleware, converter, malformed payloads, zero values, and response field ordering.

## Why

Amazon Managed Service for Prometheus users need query sample-processing information in Grafana Query Inspector. This implements grafana/oss-plugin-partnerships#1381 while leaving statistics collection disabled by default for existing Prometheus consumers.

## Screenshot

<img width="1376" height="718" alt="a-prometheus-code-editor-Data-sources-Connections-Grafana-07-21-2026_11_26_AM" src="https://github.com/user-attachments/assets/b7cc069b-56cd-4e00-a559-d86b3f09d61f" />


<img width="3186" height="2418" alt="Explore-a-prometheus-code-editor-Grafana-07-21-2026_10_56_AM" src="https://github.com/user-attachments/assets/e0793f2a-43df-4217-a0a7-51ed1918cc57" />

## Testing

- `go test -count=1 ./converter ./middleware ./models` (from `pkg/promlib`)
- `yarn workspace @grafana/prometheus typecheck`
- `yarn lint`
- `yarn test:ci`
- `yarn build`

The lint run completed with 0 errors and 10 existing untranslated-string warnings in unrelated configuration files. Webpack completed with asset-size warnings only.

## Follow-up

After this PR merges, `promlib` and `@grafana/prometheus` need to be released before the AMP integration PR can consume the final versions.
https://github.com/grafana/grafana-amazonprometheus-datasource/pull/785
