### PR TITLE
Remove promlib go.mod replace from initial commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,5 +136,3 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 )
-
-replace github.com/grafana/grafana-prometheus-datasource/pkg/promlib => ./pkg/promlib


### PR DESCRIPTION
When the first WIP commit landed, we had a promlib go.mod replace. We don't need this anymore, because we're a fully grown project.

This PR removes it.