### PR TITLE
ci: use shared reusable add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Add issues to Data Source Plugin team project
+name: Add issues & PRs to Grafana Data Source Plugins Squad project
 on:
   issues:
     types:
@@ -12,15 +12,4 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    name: Add issue to project
-    runs-on: ubuntu-latest
-    steps:
-      - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
-        with:
-          github_app: grafana-oss-big-tent
-      - name: Add to project
-        uses: actions/add-to-project@8b5d8dd2895c251002b427e4688a6115b5ed2f09 # main
-        with:
-          project-url: https://github.com/orgs/grafana/projects/1085 # Grafana Data Source Plugins Squad 🐴
-          github-token: ${{ steps.get-github-token.outputs.token }}
+    uses: grafana/data-sources-ci-workflows/.github/workflows/reusable-add-to-project.yml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Migrates the add-to-project workflow to the shared reusable workflow from `grafana/data-sources-ci-workflows`.