### PR TITLE
Chore: Improve changeset creation

### DIFF
--- a/.changeset/tired-actors-cough.md
+++ b/.changeset/tired-actors-cough.md
@@ -1,0 +1,5 @@
+---
+'grafana-prometheus-datasource': patch
+---
+
+Improve changeset creation

--- a/.github/workflows/changeset-check.yaml
+++ b/.github/workflows/changeset-check.yaml
@@ -58,6 +58,19 @@ jobs:
           echo "Found changeset file(s):"
           echo "$added_files"
 
+      - name: Verify library changesets have datasource mirrors
+        if: steps.skip-bot.outputs.skip != 'true' && steps.skip-label.outputs.skip != 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_SHA"
+          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          mapfile -t added_files < <(git diff --name-only --diff-filter=A "$merge_base" "$HEAD_SHA" -- \
+            '.changeset/*.md' ':(exclude).changeset/README.md')
+          node scripts/check-changeset-mirrors.js "${added_files[@]}"
+
       - name: Verify promlib changesets are patch-only
         if: steps.skip-bot.outputs.skip != 'true' && steps.skip-label.outputs.skip != 'true'
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,11 @@ yarn e2e
 Each PR must have a proper changeset that explains the PR's purpose in one line. That information will be used to generate a changelog when we release a new version of the respective package.
 
 To have a changeset, simply run `yarn changeset` and follow the CLI instructions.
-When you are done commit the auto-generated changeset file to your PR.
+When targeting `@grafana/prometheus` or `promlib`, the command intentionally
+creates two changeset files: one for the selected library and a datasource
+patch changeset with the same summary. Both libraries are shipped as part of
+the datasource, so commit both generated files. A direct datasource changeset
+still creates only one file.
 
 ## Project Structure
 
@@ -117,7 +121,7 @@ When you are done commit the auto-generated changeset file to your PR.
 
 - Keep PRs focused — one logical change per PR.
 - Add or update tests for any changed behaviour.
-- Run `yarn changeset` and commit the generated file — this replaces manual `CHANGELOG.md` edits.
+- Run `yarn changeset` and commit all generated files — this replaces manual `CHANGELOG.md` edits.
 - Ensure `yarn lint`, `yarn typecheck`, and `yarn test:ci` all pass locally before opening a PR.
 
 ## Release Process
@@ -156,6 +160,7 @@ The library in `packages/grafana-prometheus/` is released independently via a ma
 - Follow the CLI instructions.
   - Changesets will be aggregated and a new changelog entry will be generated.
   - Aggregated changesets will be deleted.
+  - Mirrored datasource changesets will remain pending for the next datasource release.
   - The version will be bumped in `packages/grafana-prometheus/package.json`.
   - Commit everything.
 - After merging the PR visit [Publish @grafana/prometheus to NPM](https://github.com/grafana/grafana-prometheus-datasource/actions/workflows/release-npm.yml) in actions.
@@ -178,6 +183,7 @@ The backend library in `pkg/promlib` is released (tagged) independently via a gi
 - Follow the CLI instructions.
   - Changesets will be aggregated and a new changelog entry will be generated.
   - Aggregated changesets will be deleted.
+  - Mirrored datasource changesets will remain pending for the next datasource release.
   - The version will be bumped in `packages/promlib`.
   - Commit everything.
 - After merging the PR checkout the commit you just merged. `git checkout <COMMIT_SHA>`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -134,9 +134,9 @@ The workflow will build the library and print a summary of what _would_ be publi
 
 1. **Create a release branch** from `main`, named like `release-grafana-prometheus-<version>`, and open a PR.
 
-2. **Apply pending changesets** on that branch by running `yarn changeset:version` and selecting `@grafana/prometheus` (or pass `--library`). This consumes the pending changesets, bumps the version in `packages/grafana-prometheus/package.json`, and updates its `CHANGELOG.md`.
+2. **Apply pending changesets** on that branch by running `yarn changeset:version` and selecting `@grafana/prometheus` (or pass `--npm-package`). This consumes the pending `@grafana/prometheus` changesets, bumps the version in `packages/grafana-prometheus/package.json`, and updates its `CHANGELOG.md`. The corresponding datasource changesets remain pending for the next datasource release.
 
-   > **Note:** Changesets are added in feature PRs via `yarn changeset`. Make sure every feature PR that should appear in the release includes one — without pending changesets there is nothing to version.
+   > **Note:** Changesets are added in feature PRs via `yarn changeset`. Selecting `@grafana/prometheus` intentionally creates two files with the same summary: the package changeset and a datasource patch changeset. Commit both files; without pending package changesets there is nothing to include in the package changelog.
 
    > **Note:** If a PR intentionally needs no changelog entry, add the `no-changelog` label to it so the changeset CI check passes.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,11 @@ workspace glob.
 
 ### `add-changeset.js` — `yarn changeset`
 
-Creates one `.changeset/<id>.md` for one package.
+Creates one `.changeset/<id>.md` for the selected package. Selecting
+`@grafana/prometheus` or `promlib` also creates a separate
+`grafana-prometheus-datasource` patch changeset with the same summary, because
+changes from both libraries are shipped in the datasource. The separate files
+allow each package to be released independently.
 
 ```bash
 yarn changeset                                    # fully interactive
@@ -34,7 +38,10 @@ yarn changeset --promlib        --patch "Fix promlib bug"
 Flags: `--datasource`, `--npm-package`,
 `--promlib`, plus `--patch` / `--minor` / `--major`. Anything left over is the
 summary. Missing inputs are prompted for; an empty package selection is an
-error (no default).
+error (no default). The selected package keeps the requested bump type. An
+automatically created datasource changeset is always a patch; an explicit
+datasource changeset can raise the eventual datasource release to minor or
+major.
 
 ### `version-changeset.js` — `yarn changeset:version`
 

--- a/scripts/__tests__/add-changeset.test.js
+++ b/scripts/__tests__/add-changeset.test.js
@@ -67,7 +67,7 @@ describe('add-changeset / createChangeset', () => {
   }
 
   it('writes a .changeset/<id>.md file for the datasource with the right frontmatter', async () => {
-    const id = await createChangeset({
+    const { id, datasourceId } = await createChangeset({
       pkg: DATASOURCE,
       bump: 'patch',
       summary: 'Fix panel',
@@ -76,6 +76,7 @@ describe('add-changeset / createChangeset', () => {
 
     expect(typeof id).toBe('string');
     expect(id.length).toBeGreaterThan(0);
+    expect(datasourceId).toBeNull();
 
     const mdFiles = listChangesetMdFiles(root);
     expect(mdFiles).toEqual([`${id}.md`]);
@@ -86,7 +87,7 @@ describe('add-changeset / createChangeset', () => {
   });
 
   it('writes a changeset for the npm-package with the right frontmatter', async () => {
-    const id = await createChangeset({
+    const { id, datasourceId } = await createChangeset({
       pkg: NPM_PACKAGE,
       bump: 'minor',
       summary: 'Add util',
@@ -96,10 +97,14 @@ describe('add-changeset / createChangeset', () => {
     const content = fs.readFileSync(path.join(root, '.changeset', `${id}.md`), 'utf8');
     expectFrontmatterEntry(content, NPM_PACKAGE, 'minor');
     expect(content).toContain('Add util');
+
+    const datasourceContent = fs.readFileSync(path.join(root, '.changeset', `${datasourceId}.md`), 'utf8');
+    expectFrontmatterEntry(datasourceContent, DATASOURCE, 'patch');
+    expect(datasourceContent).toContain('Add util');
   });
 
-  it('supports the major bump', async () => {
-    const id = await createChangeset({
+  it('supports the major bump while keeping the datasource mirror at patch', async () => {
+    const { id, datasourceId } = await createChangeset({
       pkg: NPM_PACKAGE,
       bump: 'major',
       summary: 'Breaking change',
@@ -107,11 +112,13 @@ describe('add-changeset / createChangeset', () => {
     });
     const content = fs.readFileSync(path.join(root, '.changeset', `${id}.md`), 'utf8');
     expectFrontmatterEntry(content, NPM_PACKAGE, 'major');
+    const datasourceContent = fs.readFileSync(path.join(root, '.changeset', `${datasourceId}.md`), 'utf8');
+    expectFrontmatterEntry(datasourceContent, DATASOURCE, 'patch');
   });
 
   it('produces files whose frontmatter is parseable by version-changeset getChangesetPackages', async () => {
     const { getChangesetPackages } = require('../version-changeset');
-    const id = await createChangeset({
+    const { id } = await createChangeset({
       pkg: DATASOURCE,
       bump: 'patch',
       summary: 'Round-trip',
@@ -143,11 +150,11 @@ describe('add-changeset / createChangeset', () => {
     await createChangeset({ pkg: DATASOURCE, bump: 'patch', summary: 'A', repoRoot: root });
     await createChangeset({ pkg: NPM_PACKAGE, bump: 'minor', summary: 'B', repoRoot: root });
 
-    expect(listChangesetMdFiles(root)).toHaveLength(2);
+    expect(listChangesetMdFiles(root)).toHaveLength(3);
   });
 
-  it('writes a changeset for promlib with the right frontmatter', async () => {
-    const id = await createChangeset({
+  it('writes separate promlib and datasource changesets with the same summary', async () => {
+    const { id, datasourceId } = await createChangeset({
       pkg: PROMLIB,
       bump: 'patch',
       summary: 'Fix promlib bug',
@@ -157,5 +164,9 @@ describe('add-changeset / createChangeset', () => {
     const content = fs.readFileSync(path.join(root, '.changeset', `${id}.md`), 'utf8');
     expectFrontmatterEntry(content, PROMLIB, 'patch');
     expect(content).toContain('Fix promlib bug');
+
+    const datasourceContent = fs.readFileSync(path.join(root, '.changeset', `${datasourceId}.md`), 'utf8');
+    expectFrontmatterEntry(datasourceContent, DATASOURCE, 'patch');
+    expect(datasourceContent).toContain('Fix promlib bug');
   });
 });

--- a/scripts/__tests__/check-changeset-mirrors.test.js
+++ b/scripts/__tests__/check-changeset-mirrors.test.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+const { findMissingMirrors, parseChangeset } = require('../check-changeset-mirrors');
+
+function changeset(filePath, releases, body) {
+  const frontmatter = Object.entries(releases)
+    .map(([pkg, bump]) => `'${pkg}': ${bump}`)
+    .join('\n');
+  return { filePath, content: `---\n${frontmatter}\n---\n\n${body}\n` };
+}
+
+describe('check-changeset-mirrors', () => {
+  it('accepts an npm package changeset with a matching datasource patch changeset', () => {
+    expect(
+      findMissingMirrors([
+        changeset('.changeset/library.md', { '@grafana/prometheus': 'minor' }, 'Add a query helper'),
+        changeset('.changeset/datasource.md', { 'grafana-prometheus-datasource': 'patch' }, 'Add a query helper'),
+      ])
+    ).toEqual([]);
+  });
+
+  it('accepts a promlib changeset with a matching datasource patch changeset', () => {
+    expect(
+      findMissingMirrors([
+        changeset('.changeset/promlib.md', { promlib: 'patch' }, 'Fix response parsing'),
+        changeset('.changeset/datasource.md', { 'grafana-prometheus-datasource': 'patch' }, 'Fix response parsing'),
+      ])
+    ).toEqual([]);
+  });
+
+  it('ignores direct datasource changesets', () => {
+    expect(
+      findMissingMirrors([
+        changeset('.changeset/datasource.md', { 'grafana-prometheus-datasource': 'minor' }, 'Add plugin feature'),
+      ])
+    ).toEqual([]);
+  });
+
+  it('reports a library changeset without a datasource changeset', () => {
+    expect(
+      findMissingMirrors([changeset('.changeset/library.md', { '@grafana/prometheus': 'patch' }, 'Fix query behavior')])
+    ).toEqual(['.changeset/library.md']);
+  });
+
+  it('requires the datasource changeset to have the same body', () => {
+    expect(
+      findMissingMirrors([
+        changeset('.changeset/library.md', { '@grafana/prometheus': 'patch' }, 'Fix query behavior'),
+        changeset('.changeset/datasource.md', { 'grafana-prometheus-datasource': 'patch' }, 'Different summary'),
+      ])
+    ).toEqual(['.changeset/library.md']);
+  });
+
+  it('requires a separate datasource-only patch changeset', () => {
+    expect(
+      findMissingMirrors([
+        changeset(
+          '.changeset/combined.md',
+          { '@grafana/prometheus': 'patch', 'grafana-prometheus-datasource': 'patch' },
+          'Fix query behavior'
+        ),
+      ])
+    ).toEqual(['.changeset/combined.md']);
+  });
+
+  it('does not accept a non-patch datasource mirror', () => {
+    expect(
+      findMissingMirrors([
+        changeset('.changeset/promlib.md', { promlib: 'patch' }, 'Fix response parsing'),
+        changeset('.changeset/datasource.md', { 'grafana-prometheus-datasource': 'minor' }, 'Fix response parsing'),
+      ])
+    ).toEqual(['.changeset/promlib.md']);
+  });
+
+  it('normalizes line endings and surrounding body whitespace', () => {
+    const parsed = parseChangeset(
+      '.changeset/example.md',
+      "---\r\n'@grafana/prometheus': patch\r\n---\r\n\r\nFix query behavior\r\n"
+    );
+
+    expect(parsed.releases).toEqual(new Map([['@grafana/prometheus', 'patch']]));
+    expect(parsed.body).toBe('Fix query behavior');
+  });
+});

--- a/scripts/__tests__/use-cases.test.js
+++ b/scripts/__tests__/use-cases.test.js
@@ -110,10 +110,15 @@ describe('Use case 1.1 — `yarn changeset` interactive', () => {
     expect(result.pkg).toBe(NPM_PACKAGE);
     expect(result.bump).toBe('minor');
 
-    const fm = readChangesetFrontmatter(root, listChangesetMdFiles(root)[0]);
+    expect(listChangesetMdFiles(root)).toHaveLength(2);
+    const fm = readChangesetFrontmatter(root, `${result.id}.md`);
     expect(fm.packages).toEqual(new Set([NPM_PACKAGE]));
     expect(fm.raw).toContain('Add new helper');
     expect(fm.raw).toMatch(/(['"]?)@grafana\/prometheus\1\s*:\s*minor/);
+
+    const datasourceFm = readChangesetFrontmatter(root, `${result.datasourceId}.md`);
+    expect(datasourceFm.packages).toEqual(new Set([DATASOURCE]));
+    expect(datasourceFm.raw).toContain('Add new helper');
   });
 
   it('user picks 1 (datasource), major, summary → produces a datasource major changeset', async () => {
@@ -173,12 +178,16 @@ describe('Use case 1.2 — `yarn changeset --npm-package --minor "..."`', () => 
     expect(prompt.calls).toEqual([]);
 
     const files = listChangesetMdFiles(root);
-    expect(files).toHaveLength(1);
+    expect(files).toHaveLength(2);
 
-    const fm = readChangesetFrontmatter(root, files[0]);
+    const fm = readChangesetFrontmatter(root, `${result.id}.md`);
     expect(fm.packages).toEqual(new Set([NPM_PACKAGE]));
     expect(fm.raw).toContain('some test for minor level change');
     expect(fm.raw).toMatch(/(['"]?)@grafana\/prometheus\1\s*:\s*minor/);
+
+    const datasourceFm = readChangesetFrontmatter(root, `${result.datasourceId}.md`);
+    expect(datasourceFm.packages).toEqual(new Set([DATASOURCE]));
+    expect(datasourceFm.raw).toContain('some test for minor level change');
   });
 });
 
@@ -270,7 +279,7 @@ describe('Use case 1.4 — `yarn changeset:version --datasource`', () => {
       log: () => {},
     });
 
-    expect(listChangesetMdFiles(root)).toHaveLength(5);
+    expect(listChangesetMdFiles(root)).toHaveLength(7);
 
     const result = await versionChangeset.run({
       argv: ['--datasource'],
@@ -309,7 +318,9 @@ describe('Use case 1.4 — `yarn changeset:version --datasource`', () => {
       .split('\n')
       .map((l) => l.trim())
       .filter((l) => l.length > 0);
-    expect(entryLines.sort()).toEqual(['- Add B', '- Break C', '- Fix A'].sort());
+    expect(entryLines.sort()).toEqual(
+      ['- Add B', '- Break C', '- Fix A', '- Lib unrelated 1', '- Lib unrelated 2'].sort()
+    );
 
     expect(fs.existsSync(path.join(root, '.changeset-hold'))).toBe(false);
   });
@@ -350,7 +361,7 @@ describe('Use case 1.5 — `yarn changeset:version --npm-package`', () => {
       log: () => {},
     });
 
-    expect(listChangesetMdFiles(root)).toHaveLength(3);
+    expect(listChangesetMdFiles(root)).toHaveLength(5);
 
     const result = await versionChangeset.run({
       argv: ['--npm-package'],
@@ -362,7 +373,7 @@ describe('Use case 1.5 — `yarn changeset:version --npm-package`', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.versioned).toBe(true);
-    expect(result.heldCount).toBe(1);
+    expect(result.heldCount).toBe(3);
 
     expect(readPackageVersion(root, LIB_REL)).toBe('13.2.0');
 
@@ -370,9 +381,11 @@ describe('Use case 1.5 — `yarn changeset:version --npm-package`', () => {
     expect(readPackageVersion(root, '.')).toBe('13.1.0');
 
     const remaining = listChangesetMdFiles(root);
-    expect(remaining).toHaveLength(1);
-    const { packages } = readChangesetFrontmatter(root, remaining[0]);
-    expect([...packages]).toEqual([DATASOURCE]);
+    expect(remaining).toHaveLength(3);
+    for (const file of remaining) {
+      const { packages } = readChangesetFrontmatter(root, file);
+      expect([...packages]).toEqual([DATASOURCE]);
+    }
 
     expect(fs.existsSync(path.join(root, '.changeset-hold'))).toBe(false);
   });
@@ -443,7 +456,7 @@ describe('Use case 1.6 — `yarn changeset:version --promlib`', () => {
       log: () => {},
     });
 
-    expect(listChangesetMdFiles(root)).toHaveLength(4);
+    expect(listChangesetMdFiles(root)).toHaveLength(7);
 
     const result = await versionChangeset.run({
       argv: ['--promlib'],
@@ -455,7 +468,7 @@ describe('Use case 1.6 — `yarn changeset:version --promlib`', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.versioned).toBe(true);
-    expect(result.heldCount).toBe(2);
+    expect(result.heldCount).toBe(5);
 
     expect(readPackageVersion(root, PROMLIB_STUB_REL)).toBe('0.1.0');
 
@@ -472,7 +485,7 @@ describe('Use case 1.6 — `yarn changeset:version --promlib`', () => {
     expect(fs.existsSync(path.join(root, PROMLIB_TARGET_REL, 'package.json'))).toBe(false);
 
     const remaining = listChangesetMdFiles(root);
-    expect(remaining).toHaveLength(2);
+    expect(remaining).toHaveLength(5);
     const remainingPackages = new Set();
     for (const file of remaining) {
       for (const pkg of versionChangeset.getChangesetPackages(path.join(root, '.changeset', file))) {

--- a/scripts/add-changeset.js
+++ b/scripts/add-changeset.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Creates a changeset for exactly one workspace package.
+// Creates changesets for a selected workspace package.
 //
 // The user MUST pick a package — either `grafana-prometheus-datasource` (the
 // stub package that mirrors the workspace root — see
@@ -7,6 +7,12 @@
 // that mirrors `pkg/promlib`'s CHANGELOG) — via `--datasource` /
 // `--npm-package` / `--promlib`, or interactively when no flag is passed. There
 // is no default.
+//
+// Changes to `@grafana/prometheus` and `promlib` are also shipped as part of
+// the datasource, so those selections create a second, independent datasource
+// patch changeset with the same summary. Keeping the changesets independent
+// lets version-changeset.js release either package without consuming the other
+// package's changelog entry.
 //
 // Usage:
 //   yarn changeset                                     # fully interactive
@@ -97,7 +103,11 @@ async function createChangeset({ pkg, bump, summary, repoRoot }) {
     throw new Error('A summary is required.');
   }
   const id = await write({ summary, releases: [{ name: pkg, type: bump }] }, repoRoot);
-  return id;
+  let datasourceId = null;
+  if (pkg !== DATASOURCE) {
+    datasourceId = await write({ summary, releases: [{ name: DATASOURCE, type: 'patch' }] }, repoRoot);
+  }
+  return { id, datasourceId };
 }
 
 // Drives the full CLI flow: parse args, fill in any missing inputs via the
@@ -119,11 +129,15 @@ async function run({ argv, repoRoot, prompt = defaultPrompt, log = console.log }
     summary = await prompt('Summary: ', '');
   }
 
-  const id = await createChangeset({ pkg, bump, summary, repoRoot });
+  const { id, datasourceId } = await createChangeset({ pkg, bump, summary, repoRoot });
 
   log(`Created .changeset/${id}.md`);
   log(`  - ${pkg}: ${bump}`);
-  return { id, pkg, bump, summary };
+  if (datasourceId) {
+    log(`Created .changeset/${datasourceId}.md`);
+    log(`  - ${DATASOURCE}: patch`);
+  }
+  return { id, datasourceId, pkg, bump, summary };
 }
 
 if (require.main === module) {

--- a/scripts/check-changeset-mirrors.js
+++ b/scripts/check-changeset-mirrors.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const DATASOURCE = 'grafana-prometheus-datasource';
+const LIBRARIES = new Set(['@grafana/prometheus', 'promlib']);
+
+function parseChangeset(filePath, content) {
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?/);
+  if (!frontmatter) {
+    return { filePath, releases: new Map(), body: '' };
+  }
+
+  const releases = new Map();
+  for (const line of frontmatter[1].split(/\r?\n/)) {
+    const release = line.match(/^\s*(?:"([^"]+)"|'([^']+)'|([^\s'":]+))\s*:\s*(patch|minor|major)\s*$/);
+    if (release) {
+      releases.set(release[1] || release[2] || release[3], release[4]);
+    }
+  }
+
+  return {
+    filePath,
+    releases,
+    body: content.slice(frontmatter[0].length).replace(/\r\n/g, '\n').trim(),
+  };
+}
+
+function findMissingMirrors(changesets) {
+  const parsed = changesets.map(({ filePath, content }) => parseChangeset(filePath, content));
+  const datasourceChangesets = parsed.filter(
+    ({ releases }) => releases.size === 1 && releases.get(DATASOURCE) === 'patch'
+  );
+
+  return parsed
+    .filter(({ releases }) => [...LIBRARIES].some((library) => releases.has(library)))
+    .filter(
+      (libraryChangeset) =>
+        !datasourceChangesets.some(
+          (datasourceChangeset) =>
+            datasourceChangeset.filePath !== libraryChangeset.filePath &&
+            datasourceChangeset.body === libraryChangeset.body
+        )
+    )
+    .map(({ filePath }) => filePath);
+}
+
+function main(filePaths) {
+  const changesets = filePaths.map((filePath) => ({
+    filePath,
+    content: fs.readFileSync(filePath, 'utf8'),
+  }));
+  const missingMirrors = findMissingMirrors(changesets);
+
+  if (missingMirrors.length > 0) {
+    for (const filePath of missingMirrors) {
+      console.error(
+        `::error file=${filePath}::Library changeset '${filePath}' must have a separate ` +
+          `${DATASOURCE} patch changeset with the same content. Run 'yarn changeset' to generate both files.`
+      );
+    }
+    return 1;
+  }
+
+  console.log('All library changesets have matching datasource patch changesets.');
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}
+
+module.exports = { DATASOURCE, LIBRARIES, parseChangeset, findMissingMirrors, main };


### PR DESCRIPTION
### What changed
- Automatically create a separate grafana-prometheus-datasource patch changeset when adding a changeset for `@grafana/prometheus` or `promlib`.
- Reuse the same changelog summary in both files.
- Keep changesets separate so each package can still be released independently.
- Document that two generated changesets are expected and should both be committed.
- Add CI validation requiring library changesets to have a matching datasource patch changeset.


### Why
Changes to @grafana/prometheus and promlib are included in the datasource through the workspace, but previously appeared only in the library changelog. This ensures those changes are also recorded in the next datasource release.

