### PR TITLE
Chore: Fix assistant bundling issue

### DIFF
--- a/.changeset/pink-toes-wave.md
+++ b/.changeset/pink-toes-wave.md
@@ -1,0 +1,5 @@
+---
+'grafana-prometheus-datasource': patch
+---
+
+Revert bundling of Assistant

--- a/.changeset/rare-guests-wave.md
+++ b/.changeset/rare-guests-wave.md
@@ -1,0 +1,5 @@
+---
+'@grafana/prometheus': patch
+---
+
+Revert bundling of Assistant

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -109,6 +109,7 @@
     "typescript": "6.0.2"
   },
   "peerDependencies": {
+    "@grafana/assistant": ">=0.1.0",
     "@grafana/data": ">=11.5.0",
     "@grafana/e2e-selectors": ">=11.5.0",
     "@grafana/i18n": ">=12.3.0",
@@ -117,6 +118,11 @@
     "@grafana/ui": ">=11.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@grafana/assistant": {
+      "optional": true
+    }
   },
   "overrides": {
     "@grafana/data": "$@grafana/data",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,7 @@ __metadata:
     typescript: "npm:6.0.2"
     uuid: "npm:14.0.0"
   peerDependencies:
+    "@grafana/assistant": ">=0.1.0"
     "@grafana/data": ">=11.5.0"
     "@grafana/e2e-selectors": ">=11.5.0"
     "@grafana/i18n": ">=12.3.0"
@@ -1662,6 +1663,9 @@ __metadata:
     "@grafana/ui": ">=11.5.0"
     react: ^18.0.0
     react-dom: ^18.0.0
+  peerDependenciesMeta:
+    "@grafana/assistant":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
i don't know the history behind [bundling assistant](https://github.com/grafana/grafana-prometheus-datasource/pull/59), but i think it broke this package in grafana. when i try to install the latest release (`v13.1.8`), i get a big wall of text related to virtual `default` rxjs exports. i asked AI and it proposed this, which i have tested locally via artifact file path and it worked.

with the changes in this PR, i get the desired effect of `moment` and `moment-timezone` removal (https://github.com/grafana/grafana-prometheus-datasource/pull/264).

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b54569ec-80b8-4b6f-bff4-3bef6d5e8316" />

---

below is the AI-assisted RCA, including validation steps to ensure any alternative fix you might propose does not introduce the same issue again:

# RCA: `@grafana/prometheus` npm package breaks consumer webpack builds (13.1.3 – 13.1.8)
## Symptom
Building Grafana core (or any webpack project) that depends on `@grafana/prometheus@>=13.1.3`
fails during webpack's export analysis with errors like:
```
ModuleDependencyError: export 'default' (reexported as 'default') was not found in 'rxjs'
ModuleDependencyError: export 'default' (reexported as 'default') was not found in '@grafana/data'
```
Raised by `FlagDependencyExportsPlugin` / `HarmonyExportImportedSpecifierDependency`.
The last unaffected version is **13.1.2**. Grafana `main` pins `13.1.2` for this reason.
## Root cause
Introduced by [PR #59 "Chore: Bundle @grafana/assistant dependency"](https://github.com/grafana/grafana-prometheus-datasource/pull/59)
(commit `3827ba6`, merged 2026-04-24, first released in 13.1.3). The PR made two relevant changes
to `packages/grafana-prometheus`:
1. **Removed `@grafana/assistant` from `peerDependencies`** (and its `peerDependenciesMeta`
   "optional" entry), leaving it only in `devDependencies`.
2. Added `@rollup/plugin-commonjs` to the Rollup pipeline so the bundling would succeed.
The package's Rollup config uses `rollup-plugin-node-externals`, which externalizes
`dependencies` and `peerDependencies` but **bundles anything that is only a devDependency**.
So after the PR, Rollup inlines the *prebuilt dist* of `@grafana/assistant` into the published
package (visible in the tarball as `dist/esm/node_modules/@grafana/assistant/dist/index.mjs`).
Because the build uses `preserveModules: true` and `output.interop: 'compat'`, Rollup emits
per-external interop shim modules for the assistant's imports under `dist/esm/_virtual/`:
```js
// dist/esm/_virtual/_rxjs.mjs
export { default } from 'rxjs';
// dist/esm/_virtual/data.mjs
export { default } from '@grafana/data';
```
(plus equivalents for `@grafana/ui`, `@grafana/runtime`, `react`).
None of these packages provide a `default` export in their ESM builds, so any consumer whose
bundler statically verifies export presence (webpack does, and Grafana core treats it as an
error) fails to build. The shims are dead-interop code, but webpack flags them regardless.
## Fix applied here
Restore the pre-PR-#59 dependency declaration so `rollup-plugin-node-externals` treats
`@grafana/assistant` as external again (the devDependency stays for building/testing):
- `packages/grafana-prometheus/package.json`: re-add `"@grafana/assistant": ">=0.1.0"` to
  `peerDependencies`, marked optional in `peerDependenciesMeta`.
- `yarn.lock`: mirrored in the `@grafana/prometheus@workspace` entry.
Note this reverts the *intent* of PR #59 (shipping the assistant so consumers don't have to
provide it). Any alternative fix that keeps the assistant bundled must pass the validation
below.
## How to validate any fix (or alternative fix)
### 1. Inspect the built artifact
```bash
yarn install
yarn workspace @grafana/prometheus build
cd packages/grafana-prometheus
```
All of these must hold:
```bash
# No interop shim directory:
test ! -e dist/esm/_virtual && test ! -e dist/cjs/_virtual
# No default re-exports from packages that have no default export:
! grep -rE "export \{ default \} from '(rxjs|react|@grafana/(data|ui|runtime|schema|e2e-selectors|i18n))'" dist/
# If the fix externalizes the assistant, it must not be inlined:
test ! -e dist/esm/node_modules && test ! -e dist/cjs/node_modules
```
The last check does not apply if the chosen fix intentionally bundles the assistant — but then
the first two are the load-bearing ones, and the assistant's code must be re-bundled from a
form that produces valid ESM (no `default` interop against default-less externals).
### 2. Integration test against a Grafana checkout
The real regression test is a consumer webpack build:
```bash
# in this repo
cd packages/grafana-prometheus
yarn pack --out /tmp/grafana-prometheus-local.tgz
# in a grafana checkout: point package.json at the artifact
#   "@grafana/prometheus": "file:/tmp/grafana-prometheus-local.tgz"
yarn install
yarn build   # must complete with no ModuleDependencyError mentioning rxjs/@grafana/*
```
Tip: bump the version (e.g. `13.1.9-local.0`) before packing, or run
`yarn cache clean @grafana/prometheus` between iterations — Yarn caches `file:` tarballs by
name+version. For fast iteration, a `portal:` pointing at
`packages/grafana-prometheus` (not the repo root — the root's `workspace:*` dep won't resolve
outside this repo) avoids repacking.
### 3. Guard against regression in CI
A cheap post-build check in this repo would have caught this at PR time, e.g. after
`yarn workspace @grafana/prometheus build`:
```bash
if [ -e packages/grafana-prometheus/dist/esm/_virtual ] || \
   grep -rqE "export \{ default \} from '(rxjs|react|@grafana/)" packages/grafana-prometheus/dist/esm; then
  echo "dist contains broken default-export interop shims (see rca-assistant-bundling.md)"; exit 1
fi
```
## Version timeline
| Version | State |
| --- | --- |
| 13.1.2 (2026-04-20) | OK — assistant is an optional peer dependency, externalized |
| 13.1.3 (2026-04-24) | **First broken release** — contains PR #59 |
| 13.1.4 – 13.1.8 | Broken — same `_virtual` shims present in every tarball |
